### PR TITLE
Remove `split_encode` in favor of encoding option

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,10 +1,11 @@
 use std::io::Write;
 
 use crate::{
+    encode,
     header::Header,
     iter::{SurfaceInfo, SurfaceIterator},
     resize::{Aligner, ResizeState},
-    split_encode, ColorFormat, DataLayout, EncodeError, EncodeOptions, Format, ImageView, Size,
+    ColorFormat, DataLayout, EncodeError, EncodeOptions, Format, ImageView, Size,
 };
 
 pub struct Encoder<W> {
@@ -136,7 +137,7 @@ impl<W> Encoder<W> {
         if current.size() != image.size() {
             return Err(EncodeError::UnexpectedSurfaceSize);
         }
-        split_encode(&mut self.writer, image, self.format, &self.options)?;
+        encode(&mut self.writer, image, self.format, &self.options)?;
         self.iter.advance();
 
         if options.generate_mipmaps
@@ -166,7 +167,7 @@ impl<W> Encoder<W> {
                 let mip =
                     ImageView::new(mip_data, mipmap_size, image.color).expect("invalid mipmap");
 
-                split_encode(&mut self.writer, mip, self.format, &self.options)?;
+                encode(&mut self.writer, mip, self.format, &self.options)?;
                 self.iter.advance();
             }
         }

--- a/test-data/encode_quality.md
+++ b/test-data/encode_quality.md
@@ -9,12 +9,12 @@
 
 ## `BC1_UNORM`
 
-- fast: EncodeOptions { dithering: None, error_metric: Uniform, quality: Fast }
-- normal: EncodeOptions { dithering: None, error_metric: Uniform, quality: Normal }
-- high: EncodeOptions { dithering: None, error_metric: Uniform, quality: High }
-- dither: EncodeOptions { dithering: ColorAndAlpha, error_metric: Uniform, quality: Normal }
-- perc: EncodeOptions { dithering: None, error_metric: Perceptual, quality: High }
-- perc d: EncodeOptions { dithering: Color, error_metric: Perceptual, quality: High }
+- fast: EncodeOptions { dithering: None, error_metric: Uniform, quality: Fast, parallel: true }
+- normal: EncodeOptions { dithering: None, error_metric: Uniform, quality: Normal, parallel: true }
+- high: EncodeOptions { dithering: None, error_metric: Uniform, quality: High, parallel: true }
+- dither: EncodeOptions { dithering: ColorAndAlpha, error_metric: Uniform, quality: Normal, parallel: true }
+- perc: EncodeOptions { dithering: None, error_metric: Perceptual, quality: High, parallel: true }
+- perc d: EncodeOptions { dithering: Color, error_metric: Perceptual, quality: High, parallel: true }
 
 |                 |        |   | ↑PSNR | ↑PSNR B | ↓Region err
 | --------------- | ------ | - | ----- | ------- | -----------
@@ -388,10 +388,10 @@
 
 ## `BC4_UNORM`
 
-- fast: EncodeOptions { dithering: None, error_metric: Uniform, quality: Fast }
-- normal: EncodeOptions { dithering: None, error_metric: Uniform, quality: Normal }
-- high: EncodeOptions { dithering: None, error_metric: Uniform, quality: High }
-- dither: EncodeOptions { dithering: ColorAndAlpha, error_metric: Uniform, quality: High }
+- fast: EncodeOptions { dithering: None, error_metric: Uniform, quality: Fast, parallel: true }
+- normal: EncodeOptions { dithering: None, error_metric: Uniform, quality: Normal, parallel: true }
+- high: EncodeOptions { dithering: None, error_metric: Uniform, quality: High, parallel: true }
+- dither: EncodeOptions { dithering: ColorAndAlpha, error_metric: Uniform, quality: High, parallel: true }
 
 |                 |        |   | ↑PSNR | ↑PSNR B | ↓Region err
 | --------------- | ------ | - | ----- | ------- | -----------
@@ -430,7 +430,7 @@
 
 ## `BC4_UNORM`
 
-- ref: EncodeOptions { dithering: None, error_metric: Uniform, quality: Unreasonable }
+- ref: EncodeOptions { dithering: None, error_metric: Uniform, quality: Unreasonable, parallel: true }
 
 |          |     |   | ↑PSNR | ↑PSNR B | ↓Region err
 | -------- | --- | - | ----- | ------- | -----------


### PR DESCRIPTION
Resolves #32

This PR removes the `split_encode` function and moves its functionality into `encode`. Now users can decide at runtime whether they want parallel encoding using `EncodingOptions::parallel`.