### PR TITLE
Add `DataLayout::is_cube_map()` for convenience

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -208,6 +208,9 @@ impl<R> Decoder<R> {
     /// For partial cube maps, only the faces that are present in the DDS file
     /// are read. The faces are arranged in the same order as for full cube
     /// maps.
+    ///
+    /// It's recommended to use `self.layout().is_cube_map()` to determine
+    /// whether the DDS file is a cube map or not.
     pub fn read_cube_map(&mut self, image: ImageViewMut) -> Result<(), DecodeError>
     where
         R: Read + Seek,

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -771,6 +771,25 @@ impl DataLayout {
         }
     }
 
+    /// Whether this layout is a cube map or partial cube map.
+    ///
+    /// If `true` is returned, this layout is guaranteed to be a
+    /// [`DataLayout::TextureArray`]. The [`TextureArray::kind()`] will be
+    /// either [`TextureArrayKind::CubeMaps`] or
+    /// [`TextureArrayKind::PartialCubeMap`].
+    ///
+    /// The texture array is **not** guaranteed to be contain exactly one
+    /// (partial) cube map.
+    pub fn is_cube_map(&self) -> bool {
+        matches!(
+            self,
+            DataLayout::TextureArray(TextureArray {
+                kind: TextureArrayKind::CubeMaps | TextureArrayKind::PartialCubeMap(_),
+                ..
+            })
+        )
+    }
+
     pub fn pixel_info(&self) -> PixelInfo {
         match self {
             DataLayout::Texture(texture) => texture.pixel_info(),

--- a/tests/layout.rs
+++ b/tests/layout.rs
@@ -148,6 +148,9 @@ fn full_layout_snapshot() {
         let format = decoder.format();
         let layout = decoder.layout();
         validate_region(&layout);
+        if layout.is_cube_map() {
+            assert!(header.is_cube_map());
+        }
 
         let mut output = String::new();
 


### PR DESCRIPTION
I noticed that it's a bit of pain to figure out whether a data layout is of a cube map. This is important to know for `Decoder::read_cube_map`. Sure, you can use `Header::is_cube_map` as well, but `Decoder` uses `DataLayout` as the source of truth, so it's better to get this information from there.

Now you can just do `decoder.layout().is_cube_map()` to figure out whether the current DDS file is a cube map.