### PR TITLE
Add rewind functionality to `Decoder` to read surfaces multiple times

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -272,7 +272,7 @@ impl<R> Decoder<R> {
     ///
     /// Note that this operation does **not** bring the decoder into a known
     /// (working) state after an error occurred.
-    pub fn rewind_to_previous_surface(&mut self) -> Result<(), DecodeError>
+    pub fn rewind_to_previous_surface(&mut self) -> Result<(), DecodingError>
     where
         R: Seek,
     {
@@ -290,7 +290,7 @@ impl<R> Decoder<R> {
     ///
     /// Note that this operation does **not** bring the decoder into a known
     /// (working) state after an error occurred.
-    pub fn rewind_to_start(&mut self) -> Result<(), DecodeError>
+    pub fn rewind_to_start(&mut self) -> Result<(), DecodingError>
     where
         R: Seek,
     {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -262,6 +262,44 @@ impl<R> Decoder<R> {
         Ok(())
     }
 
+    /// Moves to the reader back the previous surface, allowing it to be read
+    /// again.
+    ///
+    /// If there is no previous surface, this function will do nothing.
+    ///
+    /// Note that this operation does **not** bring the decoder into a known
+    /// (working) state after an error occurred.
+    pub fn rewind_to_previous_surface(&mut self) -> Result<(), DecodeError>
+    where
+        R: Seek,
+    {
+        let current_bytes = self.iter.elapsed_bytes();
+        self.iter.rewind();
+        let previous_bytes = self.iter.elapsed_bytes();
+        let seek = previous_bytes as i64 - current_bytes as i64;
+        self.reader.seek(std::io::SeekFrom::Current(seek))?;
+
+        Ok(())
+    }
+
+    /// Moves to the reader to the start of the data section of the DDS file,
+    /// making it possible to read the DDS file again.
+    ///
+    /// Note that this operation does **not** bring the decoder into a known
+    /// (working) state after an error occurred.
+    pub fn rewind_to_start(&mut self) -> Result<(), DecodeError>
+    where
+        R: Seek,
+    {
+        let elapsed_bytes = self.iter.elapsed_bytes();
+        let seek = -(elapsed_bytes as i64);
+        self.reader.seek(std::io::SeekFrom::Current(seek))?;
+
+        self.iter = SurfaceIterator::new(self.layout);
+
+        Ok(())
+    }
+
     /// Returns information about the surface about to be read.
     ///
     /// The returned value is not valid after calling `next_surface`.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -323,13 +323,13 @@ mod tests {
         }
 
         test(Header::new_image(100, 300, Format::BC1_UNORM));
-        // test(Header::new_image(100, 300, Format::BC1_UNORM).with_mipmap_count(5));
+        test(Header::new_image(100, 300, Format::BC1_UNORM).with_mipmap_count(5));
         test(Header::new_image(100, 300, Format::BC1_UNORM).with_mipmaps());
         test(Header::new_cube_map(100, 300, Format::BC1_UNORM));
-        // test(Header::new_cube_map(100, 300, Format::BC1_UNORM).with_mipmap_count(5));
+        test(Header::new_cube_map(100, 300, Format::BC1_UNORM).with_mipmap_count(5));
         test(Header::new_cube_map(100, 300, Format::BC1_UNORM).with_mipmaps());
         test(Header::new_volume(100, 300, 500, Format::BC1_UNORM));
-        // test(Header::new_volume(100, 300, 500, Format::BC1_UNORM).with_mipmap_count(5));
+        test(Header::new_volume(100, 300, 500, Format::BC1_UNORM).with_mipmap_count(5));
         test(Header::new_volume(100, 300, 500, Format::BC1_UNORM).with_mipmaps());
     }
 }


### PR DESCRIPTION
This PR adds 2 functions to `Decoder`:

1. `rewind_to_previous_surface` will change the position of the reader and the internal state of `Decoder` such that `read_surface` will read the previous surface. This allows users to read the same surface multiple times.
2. `rewind_to_start` will make it so that `read_surface` will read the first surface in the `Decoder`.

In a sense, these new operations are the opposite of `skip_surface`.

The motivation for adding these methods as [the `ImageDecoderRect` trait](https://docs.rs/image/latest/image/trait.ImageDecoderRect.html) in the `image` crate. This trait takes a `&mut self` instead of `self` like the non-rect `ImageDecoder::read_image`, which means that users can read rects from an image multiple times. So `Decoder` needs to have this ability, so that I can implement `ImageDecoderRect` later.

---

This PR is a draft, because some new tests use the changed API from #40. I'll update this PR after #40 is in.