### PR TITLE
Rename main error types to `EncodingError` and `DecodingError`

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use decoder::*;
 use sub_sampled::*;
 use uncompressed::*;
 
-use crate::{ColorFormat, DecodeError, Format, ImageViewMut, Rect, Size};
+use crate::{ColorFormat, DecodingError, Format, ImageViewMut, Rect, Size};
 
 pub(crate) const fn get_decoders(format: Format) -> DecoderSet {
     match format {
@@ -132,7 +132,7 @@ pub fn decode(
     image: ImageViewMut,
     format: Format,
     options: &DecodeOptions,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     get_decoders(format).decode(reader, image, options)
 }
 
@@ -169,7 +169,7 @@ pub fn decode_rect<R: Read + Seek>(
     rect: Rect,
     format: Format,
     options: &DecodeOptions,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     let reader = reader as &mut dyn ReadSeek;
     let decoders = get_decoders(format);
     decoders.decode_rect(color, reader, size, rect, output, row_pitch, options)

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -181,7 +181,7 @@ pub struct DecodeOptions {
     /// The maximum amount of memory that the decoder is allowed to allocate.
     ///
     /// If the decoder needs to allocate more memory than this limit, it will
-    /// return [`DecodeError::MemoryLimitExceeded`].
+    /// return [`DecodingError::MemoryLimitExceeded`].
     ///
     /// While most decoders can make do with a few kilobytes of stack memory,
     /// some formats require a variable amount of memory depending on the size

--- a/src/decode/read_write.rs
+++ b/src/decode/read_write.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 use std::mem::size_of;
 
 use crate::util::round_down_to_multiple;
-use crate::{cast, util::div_ceil, DecodeError, Rect, Size};
+use crate::{cast, util::div_ceil, DecodingError, Rect, Size};
 use crate::{convert_channels_for, util, Channels, ColorFormat};
 
 use super::{DecodeContext, ReadSeek};
@@ -92,7 +92,7 @@ pub(crate) fn for_each_pixel_untyped(
     native_color: ColorFormat,
     pixel_size: PixelSize,
     process_pixels: ProcessPixelsFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     fn inner(
         r: &mut dyn Read,
         buf: &mut [u8],
@@ -100,7 +100,7 @@ pub(crate) fn for_each_pixel_untyped(
         native_color: ColorFormat,
         size_of_in: usize,
         process_pixels: ProcessPixelsFn,
-    ) -> Result<(), DecodeError> {
+    ) -> Result<(), DecodingError> {
         let buf_color = context.color;
         let buf_bytes_per_pixel = buf_color.bytes_per_pixel() as usize;
         assert!(buf.len() % buf_bytes_per_pixel == 0);
@@ -146,7 +146,7 @@ pub(crate) fn for_each_pixel_rect_untyped(
     native_color: ColorFormat,
     pixel_size: PixelSize,
     process_pixels: ProcessPixelsFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     #[allow(clippy::too_many_arguments)]
     fn inner(
         r: &mut dyn ReadSeek,
@@ -157,7 +157,7 @@ pub(crate) fn for_each_pixel_rect_untyped(
         native_color: ColorFormat,
         size_of_in: usize,
         process_pixels: ProcessPixelsFn,
-    ) -> Result<(), DecodeError> {
+    ) -> Result<(), DecodingError> {
         let size = context.size;
         let buf_color = context.color;
 
@@ -532,7 +532,7 @@ pub(crate) fn for_each_block_untyped<
     context: DecodeContext,
     native_color: ColorFormat,
     process_pixels: ProcessBlocksFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     #[allow(clippy::too_many_arguments)]
     fn inner(
         r: &mut dyn Read,
@@ -542,7 +542,7 @@ pub(crate) fn for_each_block_untyped<
         bytes_per_block: usize,
         native_color: ColorFormat,
         process_blocks: ProcessBlocksFn,
-    ) -> Result<(), DecodeError> {
+    ) -> Result<(), DecodingError> {
         let size = context.size;
         let buf_color = context.color;
 
@@ -624,7 +624,7 @@ pub(crate) fn for_each_block_rect_untyped<
     rect: Rect,
     native_color: ColorFormat,
     process_pixels: ProcessBlocksFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     #[allow(clippy::too_many_arguments)]
     fn inner(
         r: &mut dyn ReadSeek,
@@ -636,7 +636,7 @@ pub(crate) fn for_each_block_rect_untyped<
         bytes_per_block: usize,
         native_color: ColorFormat,
         process_blocks: ProcessBlocksFn,
-    ) -> Result<(), DecodeError> {
+    ) -> Result<(), DecodingError> {
         let size = context.size;
         let buf_color = context.color;
 
@@ -1013,7 +1013,7 @@ impl UntypedPixelBuffer {
         self.buf.len() / self.bytes_per_pixel
     }
 
-    fn read<R: Read + ?Sized>(&mut self, r: &mut R) -> Result<&[u8], DecodeError> {
+    fn read<R: Read + ?Sized>(&mut self, r: &mut R) -> Result<&[u8], DecodingError> {
         let full_pixel_bytes = self.buf.len() / self.bytes_per_pixel * self.bytes_per_pixel;
         let bytes_to_read = full_pixel_bytes.min(self.bytes_left);
         assert!(bytes_to_read > 0);
@@ -1042,7 +1042,7 @@ impl UntypedLineBuffer {
         bytes_per_line: usize,
         height: usize,
         context: &mut DecodeContext,
-    ) -> Result<Self, DecodeError> {
+    ) -> Result<Self, DecodingError> {
         const TARGET_BUFFER_SIZE: usize = 64 * 1024; // 64 KB
 
         let lines_in_buffer = (TARGET_BUFFER_SIZE / bytes_per_line).clamp(1, height);
@@ -1059,7 +1059,7 @@ impl UntypedLineBuffer {
     }
 
     // CURSE YOU, lack of trait up-casting
-    fn next_line<R: Read + ?Sized>(&mut self, r: &mut R) -> Result<Option<&[u8]>, DecodeError> {
+    fn next_line<R: Read + ?Sized>(&mut self, r: &mut R) -> Result<Option<&[u8]>, DecodingError> {
         if self.current_line_start >= self.buf_filled {
             if self.lines_on_disk == 0 {
                 // all lines have been read
@@ -1180,7 +1180,7 @@ pub(crate) fn for_each_bi_planar(
     native_color: ColorFormat,
     info: BiPlaneInfo,
     process_bi_planar: ProcessBiPlanarFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     let size = context.size;
     let buf_color = context.color;
     debug_assert_eq!(buf_color.precision, native_color.precision);
@@ -1244,7 +1244,7 @@ pub(crate) fn for_each_bi_planar_rect(
     native_color: ColorFormat,
     info: BiPlaneInfo,
     process_bi_planar: ProcessBiPlanarFn,
-) -> Result<(), DecodeError> {
+) -> Result<(), DecodingError> {
     let size = context.size;
     let buf_color = context.color;
     debug_assert_eq!(buf_color.precision, native_color.precision);

--- a/src/encode/bc.rs
+++ b/src/encode/bc.rs
@@ -3,7 +3,7 @@
 use crate::{
     cast, ch, convert_to_rgba_f32, n4,
     util::{self, clamp_0_1},
-    EncodeError, Report,
+    EncodingError, Report,
 };
 
 use super::{
@@ -19,7 +19,7 @@ fn block_universal<
 >(
     args: Args,
     encode_block: fn(&[[f32; 4]], usize, &EncodeOptions, &mut [u8; BLOCK_BYTES]),
-) -> Result<(), EncodeError> {
+) -> Result<(), EncodingError> {
     let Args {
         data,
         color,

--- a/src/encode/bi_planar.rs
+++ b/src/encode/bi_planar.rs
@@ -6,14 +6,14 @@ use super::{
 };
 use crate::{
     cast::{self, ToLe},
-    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodeError, Report, SizeMultiple,
+    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report, SizeMultiple,
 };
 
 #[allow(clippy::type_complexity)]
 fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + cast::Castable>(
     args: Args,
     encode_macro_pixel: fn([[f32; 4]; 4], &EncodeOptions) -> ([P1; 4], P2),
-) -> Result<(), EncodeError> {
+) -> Result<(), EncodingError> {
     const BLOCK_WIDTH: usize = 2;
     const BLOCK_HEIGHT: usize = 2;
 
@@ -30,7 +30,7 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
     let bytes_per_pixel = color.bytes_per_pixel() as usize;
 
     if width % BLOCK_WIDTH != 0 || height % BLOCK_HEIGHT != 0 {
-        return Err(EncodeError::InvalidSize(SizeMultiple::new(
+        return Err(EncodingError::InvalidSize(SizeMultiple::new(
             BLOCK_WIDTH as u8,
             BLOCK_HEIGHT as u8,
         )));

--- a/src/encode/sub_sampled.rs
+++ b/src/encode/sub_sampled.rs
@@ -1,4 +1,4 @@
-use crate::{as_rgba_f32, cast, ch, n1, n8, util, yuv16, yuv8, EncodeError, Report};
+use crate::{as_rgba_f32, cast, ch, n1, n8, util, yuv16, yuv8, EncodingError, Report};
 
 use super::encoder::{Args, Encoder, EncoderSet, Flags};
 
@@ -33,7 +33,7 @@ fn uncompressed_universal_subsample<EncodedBlock>(
     args: Args,
     block_width: usize,
     process: fn(&[[f32; 4]], &mut [EncodedBlock]),
-) -> Result<(), EncodeError>
+) -> Result<(), EncodingError>
 where
     EncodedBlock: Default + Copy + cast::ToLe + cast::Castable,
 {

--- a/src/encode/uncompressed.rs
+++ b/src/encode/uncompressed.rs
@@ -3,7 +3,7 @@ use glam::Vec4;
 use crate::{
     as_rgba_f32, cast, ch, convert_channels, convert_channels_for, fp10, fp11, fp16, n1, n10, n16,
     n2, n4, n5, n6, n8, rgb9995f, s16, s8, util, xr10, yuv10, yuv16, yuv8, Channels, ColorFormat,
-    ColorFormatSet, EncodeError, Precision, Report,
+    ColorFormatSet, EncodingError, Precision, Report,
 };
 
 use super::{
@@ -18,7 +18,7 @@ const REPORT_FREQUENCY: usize = 2048;
 fn uncompressed_universal<EncodedPixel>(
     args: Args,
     process: fn(&[[f32; 4]], &mut [EncodedPixel]),
-) -> Result<(), EncodeError>
+) -> Result<(), EncodingError>
 where
     EncodedPixel: Default + Copy + cast::ToLe + cast::Castable,
 {
@@ -59,7 +59,7 @@ where
     Ok(())
 }
 
-fn uncompressed_universal_dither<EncodedPixel, F>(args: Args, f: F) -> Result<(), EncodeError>
+fn uncompressed_universal_dither<EncodedPixel, F>(args: Args, f: F) -> Result<(), EncodingError>
 where
     EncodedPixel: Default + Copy + cast::ToLe + cast::Castable,
     F: Fn(Vec4) -> (EncodedPixel, Vec4),
@@ -145,7 +145,7 @@ fn uncompressed_untyped(
     args: Args,
     bytes_per_encoded_pixel: usize,
     f: fn(&[u8], ColorFormat, &mut [u8]),
-) -> Result<(), EncodeError> {
+) -> Result<(), EncodingError> {
     let Args {
         data,
         color,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -5,8 +5,8 @@ use crate::{
     header::Header,
     iter::{SurfaceInfo, SurfaceIterator},
     resize::{Aligner, ResizeState},
-    sub_progress, ColorFormat, DataLayout, EncodeError, EncodeOptions, Format, ImageView, Progress,
-    ProgressRange, Report, Size,
+    sub_progress, ColorFormat, DataLayout, EncodeOptions, EncodingError, Format, ImageView,
+    Progress, ProgressRange, Report, Size,
 };
 
 /// An encoder for DDS files.
@@ -32,12 +32,12 @@ impl<W> Encoder<W> {
     ///
     /// If the given format does not support encoding,
     /// [`EncodeError::UnsupportedFormat`] is returned.
-    pub fn new(mut writer: W, format: Format, header: &Header) -> Result<Self, EncodeError>
+    pub fn new(mut writer: W, format: Format, header: &Header) -> Result<Self, EncodingError>
     where
         W: Write,
     {
         if format.encoding_support().is_none() {
-            return Err(EncodeError::UnsupportedFormat(format));
+            return Err(EncodingError::UnsupportedFormat(format));
         }
 
         let layout = DataLayout::from_header_with(header, format.into())?;
@@ -86,7 +86,7 @@ impl<W> Encoder<W> {
     /// volume textures, this function will write the next depth slice.
     ///
     /// See [`Self::surface_info`] for more information about the surface.
-    pub fn write_surface(&mut self, image: ImageView) -> Result<(), EncodeError>
+    pub fn write_surface(&mut self, image: ImageView) -> Result<(), EncodingError>
     where
         W: Write,
     {
@@ -104,7 +104,7 @@ impl<W> Encoder<W> {
         image: ImageView,
         progress: Option<&mut Progress>,
         options: &WriteOptions,
-    ) -> Result<(), EncodeError>
+    ) -> Result<(), EncodingError>
     where
         W: Write,
     {
@@ -116,14 +116,14 @@ impl<W> Encoder<W> {
         image: ImageView,
         mut progress: Option<&mut Progress>,
         options: &WriteOptions,
-    ) -> Result<(), EncodeError>
+    ) -> Result<(), EncodingError>
     where
         W: Write,
     {
         // Get information about the current surface.
-        let current = self.iter.current().ok_or(EncodeError::TooManySurfaces)?;
+        let current = self.iter.current().ok_or(EncodingError::TooManySurfaces)?;
         if current.size() != image.size() {
-            return Err(EncodeError::UnexpectedSurfaceSize);
+            return Err(EncodingError::UnexpectedSurfaceSize);
         }
 
         // Figure out how many mipmaps we'll generate ahead of time.
@@ -244,12 +244,12 @@ impl<W> Encoder<W> {
     ///
     /// This will return [`EncodeError::MissingSurfaces`] if some surfaces are
     /// yet to be written. See [`Self::is_done`].
-    pub fn finish(mut self) -> Result<(), EncodeError>
+    pub fn finish(mut self) -> Result<(), EncodingError>
     where
         W: Write,
     {
         if !self.is_done() {
-            return Err(EncodeError::MissingSurfaces);
+            return Err(EncodingError::MissingSurfaces);
         }
         self.writer.flush()?;
         Ok(())

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -31,7 +31,7 @@ impl<W> Encoder<W> {
     /// to detect the format.
     ///
     /// If the given format does not support encoding,
-    /// [`EncodeError::UnsupportedFormat`] is returned.
+    /// [`EncodingError::UnsupportedFormat`] is returned.
     pub fn new(mut writer: W, format: Format, header: &Header) -> Result<Self, EncodingError>
     where
         W: Write,
@@ -242,7 +242,7 @@ impl<W> Encoder<W> {
     ///
     /// If you need the writer after this call, use [`Self::into_writer`].
     ///
-    /// This will return [`EncodeError::MissingSurfaces`] if some surfaces are
+    /// This will return [`EncodingError::MissingSurfaces`] if some surfaces are
     /// yet to be written. See [`Self::is_done`].
     pub fn finish(mut self) -> Result<(), EncodingError>
     where

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,7 +83,7 @@ impl std::error::Error for LayoutError {}
 
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum DecodeError {
+pub enum DecodingError {
     /// When decoding a rectangle, the rectangle is out of bounds of the size
     /// of the image.
     RectOutOfBounds,
@@ -124,79 +124,79 @@ pub enum DecodeError {
     Io(std::io::Error),
 }
 
-impl std::fmt::Display for DecodeError {
+impl std::fmt::Display for DecodingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DecodeError::RectOutOfBounds => {
+            DecodingError::RectOutOfBounds => {
                 write!(f, "Rectangle is out of bounds of the image size")
             }
-            DecodeError::RowPitchTooSmall { required_minimum } => {
+            DecodingError::RowPitchTooSmall { required_minimum } => {
                 write!(
                     f,
                     "Row pitch too small: Must be at least `color.bytes_per_pixel() * rect.width` == {} bytes",
                     required_minimum
                 )
             }
-            DecodeError::RectBufferTooSmall { required_minimum } => {
+            DecodingError::RectBufferTooSmall { required_minimum } => {
                 write!(
                     f,
                     "Buffer too small for rectangle: required at least {} bytes",
                     required_minimum
                 )
             }
-            DecodeError::UnexpectedSurfaceSize => {
+            DecodingError::UnexpectedSurfaceSize => {
                 write!(f, "Unexpected size of the surface")
             }
-            DecodeError::CannotSkipMipmapsInVolume => {
+            DecodingError::CannotSkipMipmapsInVolume => {
                 write!(f, "Cannot skip mipmaps within a volume texture")
             }
-            DecodeError::NoMoreSurfaces => {
+            DecodingError::NoMoreSurfaces => {
                 write!(f, "No more surfaces to decode")
             }
-            DecodeError::NotACubeMap => {
+            DecodingError::NotACubeMap => {
                 write!(f, "The DDS file is not a cube map")
             }
 
-            DecodeError::MemoryLimitExceeded => {
+            DecodingError::MemoryLimitExceeded => {
                 write!(f, "Memory limit exceeded")
             }
 
-            DecodeError::Layout(error) => write!(f, "{}", error),
-            DecodeError::Format(error) => write!(f, "{}", error),
-            DecodeError::Header(error) => write!(f, "Header error: {}", error),
-            DecodeError::Io(error) => write!(f, "I/O error: {}", error),
+            DecodingError::Layout(error) => write!(f, "{}", error),
+            DecodingError::Format(error) => write!(f, "{}", error),
+            DecodingError::Header(error) => write!(f, "Header error: {}", error),
+            DecodingError::Io(error) => write!(f, "I/O error: {}", error),
         }
     }
 }
 
-impl From<LayoutError> for DecodeError {
+impl From<LayoutError> for DecodingError {
     fn from(error: LayoutError) -> Self {
-        DecodeError::Layout(error)
+        DecodingError::Layout(error)
     }
 }
-impl From<FormatError> for DecodeError {
+impl From<FormatError> for DecodingError {
     fn from(error: FormatError) -> Self {
-        DecodeError::Format(error)
+        DecodingError::Format(error)
     }
 }
-impl From<HeaderError> for DecodeError {
+impl From<HeaderError> for DecodingError {
     fn from(error: HeaderError) -> Self {
-        DecodeError::Header(error)
+        DecodingError::Header(error)
     }
 }
-impl From<std::io::Error> for DecodeError {
+impl From<std::io::Error> for DecodingError {
     fn from(error: std::io::Error) -> Self {
-        DecodeError::Io(error)
+        DecodingError::Io(error)
     }
 }
 
-impl std::error::Error for DecodeError {
+impl std::error::Error for DecodingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            DecodeError::Layout(error) => Some(error),
-            DecodeError::Format(error) => Some(error),
-            DecodeError::Header(error) => Some(error),
-            DecodeError::Io(error) => Some(error),
+            DecodingError::Layout(error) => Some(error),
+            DecodingError::Format(error) => Some(error),
+            DecodingError::Header(error) => Some(error),
+            DecodingError::Io(error) => Some(error),
             _ => None,
         }
     }
@@ -295,7 +295,7 @@ impl std::error::Error for HeaderError {
 
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum EncodeError {
+pub enum EncodingError {
     UnsupportedFormat(Format),
     InvalidSize(SizeMultiple),
     /// Returned by [`crate::encode()`] when the user tries to write a surface
@@ -317,45 +317,47 @@ pub enum EncodeError {
     Io(std::io::Error),
 }
 
-impl std::fmt::Display for EncodeError {
+impl std::fmt::Display for EncodingError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            EncodeError::UnsupportedFormat(format) => {
+            EncodingError::UnsupportedFormat(format) => {
                 write!(f, "Unsupported format: {:?}", format)
             }
-            EncodeError::InvalidSize(size) => {
+            EncodingError::InvalidSize(size) => {
                 write!(f, "Size is not a multiple of {:?}", size)
             }
-            EncodeError::EmptySurface => write!(f, "Surface has a width or height of 0"),
+            EncodingError::EmptySurface => write!(f, "Surface has a width or height of 0"),
 
-            EncodeError::UnexpectedSurfaceSize => {
+            EncodingError::UnexpectedSurfaceSize => {
                 write!(f, "Unexpected size of the surface")
             }
-            EncodeError::TooManySurfaces => write!(f, "Too many surfaces are attempted to written"),
-            EncodeError::MissingSurfaces => write!(f, "Not enough surfaces have been written"),
+            EncodingError::TooManySurfaces => {
+                write!(f, "Too many surfaces are attempted to written")
+            }
+            EncodingError::MissingSurfaces => write!(f, "Not enough surfaces have been written"),
 
-            EncodeError::Layout(err) => write!(f, "Layout error: {}", err),
-            EncodeError::Io(err) => write!(f, "IO error: {}", err),
+            EncodingError::Layout(err) => write!(f, "Layout error: {}", err),
+            EncodingError::Io(err) => write!(f, "IO error: {}", err),
         }
     }
 }
-impl std::error::Error for EncodeError {
+impl std::error::Error for EncodingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            EncodeError::Layout(err) => Some(err),
-            EncodeError::Io(err) => Some(err),
+            EncodingError::Layout(err) => Some(err),
+            EncodingError::Io(err) => Some(err),
             _ => None,
         }
     }
 }
 
-impl From<LayoutError> for EncodeError {
+impl From<LayoutError> for EncodingError {
     fn from(err: LayoutError) -> Self {
-        EncodeError::Layout(err)
+        EncodingError::Layout(err)
     }
 }
-impl From<std::io::Error> for EncodeError {
+impl From<std::io::Error> for EncodingError {
     fn from(err: std::io::Error) -> Self {
-        EncodeError::Io(err)
+        EncodingError::Io(err)
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, NonZeroU8};
 use bitflags::bitflags;
 
 use crate::header::{Caps2, Header, ResourceDimension};
-use crate::DecodeError;
+use crate::DecodingError;
 use crate::{
     util::{get_mipmap_size, NON_ZERO_U32_ONE},
     LayoutError, PixelInfo, Size,
@@ -665,7 +665,7 @@ pub enum DataLayout {
     TextureArray(TextureArray),
 }
 impl DataLayout {
-    pub fn from_header(header: &Header) -> Result<Self, DecodeError> {
+    pub fn from_header(header: &Header) -> Result<Self, DecodingError> {
         let layout = Self::from_header_with(header, PixelInfo::from_header(header)?)?;
         Ok(layout)
     }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -358,18 +358,18 @@ fn test_rect_out_of_bounds() {
     };
 
     let result = decode_dummy(Rect::new(0, 0, 100, 100), &mut [], 0);
-    assert!(matches!(result, Err(DecodeError::RectOutOfBounds)));
+    assert!(matches!(result, Err(DecodingError::RectOutOfBounds)));
     assert_eq!(
         format!("{}", result.unwrap_err()),
         "Rectangle is out of bounds of the image size"
     );
 
     let result = decode_dummy(Rect::new(2, 2, 1, 1), &mut [], 0);
-    assert!(matches!(result, Err(DecodeError::RectOutOfBounds)));
+    assert!(matches!(result, Err(DecodingError::RectOutOfBounds)));
 
     // even empty rect can be OoB
     let result = decode_dummy(Rect::new(4, 0, 0, 0), &mut [], 0);
-    assert!(matches!(result, Err(DecodeError::RectOutOfBounds)));
+    assert!(matches!(result, Err(DecodingError::RectOutOfBounds)));
     // edge case: empty rect at the end of the image
     let result = decode_dummy(Rect::new(2, 3, 0, 0), &mut [], 0);
     assert!(matches!(result, Ok(())));

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -15,13 +15,13 @@ fn encode_image<T: WithPrecision + util::Castable, W: std::io::Write>(
     format: Format,
     writer: &mut W,
     options: &EncodeOptions,
-) -> Result<(), EncodeError> {
+) -> Result<(), EncodingError> {
     encode(writer, image.view(), format, None, options)
 }
 fn write_image<T: WithPrecision + util::Castable, W: std::io::Write>(
     encoder: &mut Encoder<W>,
     image: &Image<T>,
-) -> Result<(), EncodeError> {
+) -> Result<(), EncodingError> {
     encoder.write_surface(image.view())
 }
 fn encode_decode(

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -52,7 +52,7 @@ fn track_progress() {
         options: &EncodeOptions,
         image: ImageView,
         mipmaps: bool,
-    ) -> Result<String, EncodeError> {
+    ) -> Result<String, EncodingError> {
         let mut progress_report = String::new();
         let start_time = std::time::Instant::now();
         let log_time = |progress_report: &mut String| {
@@ -181,7 +181,11 @@ fn forward_progress() {
 
     let formats = [Format::BC1_UNORM, Format::BC4_UNORM];
 
-    fn test(format: Format, options: &EncodeOptions, image: ImageView) -> Result<(), EncodeError> {
+    fn test(
+        format: Format,
+        options: &EncodeOptions,
+        image: ImageView,
+    ) -> Result<(), EncodingError> {
         let mut last_progress = 0.0;
         let mut consume_progress = |progress| {
             assert!(progress >= last_progress);


### PR DESCRIPTION
To be consistent with the `image` crate and the `png` crate, I renamed the 2 main error types to `EncodingError` and `DecodingError`. There's not much motivation otherwise.

---

Closes #29