### PR TITLE
Fixed lifetime of `ImageViewMut::data()`

### DIFF
--- a/src/decode/decoder.rs
+++ b/src/decode/decoder.rs
@@ -219,7 +219,7 @@ impl DecoderSet {
     pub fn decode(
         &self,
         reader: &mut dyn Read,
-        image: ImageViewMut,
+        mut image: ImageViewMut,
         options: &DecodeOptions,
     ) -> Result<(), DecodingError> {
         let color = image.color();
@@ -227,7 +227,7 @@ impl DecoderSet {
 
         let args = Args::new(
             reader,
-            image.data,
+            image.data(),
             DecodeContext {
                 color,
                 size,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -211,7 +211,7 @@ impl<R> Decoder<R> {
     ///
     /// It's recommended to use `self.layout().is_cube_map()` to determine
     /// whether the DDS file is a cube map or not.
-    pub fn read_cube_map(&mut self, image: ImageViewMut) -> Result<(), DecodingError>
+    pub fn read_cube_map(&mut self, mut image: ImageViewMut) -> Result<(), DecodingError>
     where
         R: Read + Seek,
     {
@@ -243,7 +243,7 @@ impl<R> Decoder<R> {
         let bytes_per_pixel = color.bytes_per_pixel() as usize;
         let row_pitch = image.row_pitch();
         let rect = Rect::new(0, 0, face_size.width, face_size.height);
-        let image_bytes = image.data;
+        let image_bytes = image.data();
 
         for (_, x, y) in face_offsets
             .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl<'a> ImageViewMut<'a> {
         Some(Self { data, size, color })
     }
 
-    pub fn data(&'a mut self) -> &'a mut [u8] {
+    pub fn data(&mut self) -> &mut [u8] {
         self.data
     }
 


### PR DESCRIPTION
It was very difficult for the lifetime of `self` to be `'a`, which made the `data()` method almost useless. With elided lifetimes, this is no longer an issue.

This also finally allowed me to use the `data()` method in my own code.