### PR TITLE
Remove public `SizeMultiple` type

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -202,7 +202,7 @@ pub fn encode_compressed(c: &mut Criterion) {
     bench_encoder(c, Format::BC4_UNORM, normal, &random_rgb);
     bench_encoder(c, Format::BC4_UNORM, high, &random_rgb);
     bench_encoder(c, Format::BC4_UNORM, dither, &random_rgb);
-    bench_encoder(c, Format::BC4_UNORM, unreasonable, &random_tiny);
+    // bench_encoder(c, Format::BC4_UNORM, unreasonable, &random_tiny);
 }
 
 pub fn generate_mipmaps(c: &mut Criterion) {
@@ -239,8 +239,8 @@ pub fn generate_mipmaps(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    encode_uncompressed,
+    // encode_uncompressed,
     encode_compressed,
-    generate_mipmaps
+    // generate_mipmaps
 );
 criterion_main!(benches);

--- a/src/encode/bi_planar.rs
+++ b/src/encode/bi_planar.rs
@@ -1,12 +1,14 @@
 // helpers
 
+use std::num::NonZeroU32;
+
 use super::{
     encoder::{Args, Encoder, EncoderSet},
     EncodeOptions,
 };
 use crate::{
     cast::{self, ToLe},
-    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report, Size,
+    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report,
 };
 
 #[allow(clippy::type_complexity)]
@@ -30,10 +32,10 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
     let bytes_per_pixel = color.bytes_per_pixel() as usize;
 
     if width % BLOCK_WIDTH != 0 || height % BLOCK_HEIGHT != 0 {
-        return Err(EncodingError::InvalidSize(Size::new(
-            BLOCK_WIDTH as u32,
-            BLOCK_HEIGHT as u32,
-        )));
+        return Err(EncodingError::InvalidSize(
+            NonZeroU32::new(BLOCK_WIDTH as u32).unwrap(),
+            NonZeroU32::new(BLOCK_HEIGHT as u32).unwrap(),
+        ));
     }
 
     let mut intermediate_buffer = vec![[0_f32; 4]; width * BLOCK_HEIGHT];

--- a/src/encode/bi_planar.rs
+++ b/src/encode/bi_planar.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     cast::{self, ToLe},
-    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report, SizeMultiple,
+    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report, Size,
 };
 
 #[allow(clippy::type_complexity)]
@@ -30,9 +30,9 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
     let bytes_per_pixel = color.bytes_per_pixel() as usize;
 
     if width % BLOCK_WIDTH != 0 || height % BLOCK_HEIGHT != 0 {
-        return Err(EncodingError::InvalidSize(SizeMultiple::new(
-            BLOCK_WIDTH as u8,
-            BLOCK_HEIGHT as u8,
+        return Err(EncodingError::InvalidSize(Size::new(
+            BLOCK_WIDTH as u32,
+            BLOCK_HEIGHT as u32,
         )));
     }
 

--- a/src/encode/encoder.rs
+++ b/src/encode/encoder.rs
@@ -4,10 +4,11 @@ use bitflags::bitflags;
 
 use crate::{
     cast, ColorFormat, ColorFormatSet, EncodingError, ImageView, Precision, Progress, Report,
-    SizeMultiple,
 };
 
-use super::{Dithering, EncodeOptions, EncodingSupport, PreferredGroupSize};
+use super::{
+    Dithering, EncodeOptions, EncodingSupport, PreferredGroupSize, SizeMultiple, SIZE_MUL_2X2,
+};
 
 pub(crate) struct Args<'a, 'b, 'c, 'd> {
     pub data: &'a [u8],
@@ -143,7 +144,7 @@ bitflags! {
 pub(crate) struct EncoderSet {
     flags: EncodeFormatFlags,
     split_height: Option<NonZeroU8>,
-    size_multiple: SizeMultiple,
+    size_multiple: Option<SizeMultiple>,
     encoders: &'static [Encoder],
 }
 impl EncoderSet {
@@ -178,7 +179,7 @@ impl EncoderSet {
         Self {
             flags,
             split_height: NonZeroU8::new(1),
-            size_multiple: SizeMultiple::ONE,
+            size_multiple: None,
             encoders,
         }
     }
@@ -191,7 +192,7 @@ impl EncoderSet {
     pub const fn new_bi_planar(encoders: &'static [Encoder]) -> Self {
         let mut set = Self::new(encoders);
         set.split_height = None;
-        set.size_multiple = SizeMultiple::M2_2;
+        set.size_multiple = Some(SIZE_MUL_2X2);
         set
     }
 

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -480,17 +480,25 @@ impl EncodingSupport {
     /// If `Some` is returned, the width and height of the returned value are
     /// both non-zero, and at least one of them is greater than 1.
     ///
+    /// Use [`EncodingSupport::supports_size()`] to check if a given image size
+    /// is supported by the format.
+    ///
     /// # Example
     ///
     /// ```
     /// # use dds::*;
+    /// let format = Format::NV12;
+    /// let encoding = format.encoding_support().unwrap();
+    ///
     /// assert_eq!(
-    ///     Format::NV12.encoding_support().unwrap().size_multiple(),
+    ///     encoding.size_multiple(),
     ///     Some(Size {
     ///         width: 2,
     ///         height: 2,
     ///     })
     /// );
+    /// assert_eq!(encoding.supports_size(Size::new(2, 2)), true);
+    /// assert_eq!(encoding.supports_size(Size::new(3, 2)), false);
     /// ```
     pub const fn size_multiple(&self) -> Option<Size> {
         if let Some((w, h)) = self.size_multiple {
@@ -500,6 +508,17 @@ impl EncodingSupport {
             })
         } else {
             None
+        }
+    }
+    /// Whether the given image size is supported for encoding.
+    ///
+    /// This will always return `true` if [`EncodingSupport::size_multiple()`]
+    /// is `None`.
+    pub const fn supports_size(&self, size: Size) -> bool {
+        if let Some((w, h)) = self.size_multiple {
+            size.width % w.get() as u32 == 0 && size.height % h.get() as u32 == 0
+        } else {
+            true
         }
     }
 

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -411,7 +411,13 @@ impl PreferredGroupSize {
 }
 
 pub(crate) type SizeMultiple = (NonZeroU8, NonZeroU8);
-const SIZE_MUL_2X2: SizeMultiple = (NonZeroU8::new(2).unwrap(), NonZeroU8::new(2).unwrap());
+const SIZE_MUL_2X2: SizeMultiple = {
+    if let Some(two) = NonZeroU8::new(2) {
+        (two, two)
+    } else {
+        unreachable!()
+    }
+};
 
 /// Describes the extent of support for encoding a format.
 #[derive(Debug, Clone, Copy)]

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -1,4 +1,7 @@
-use std::{io::Write, num::NonZeroU8};
+use std::{
+    io::Write,
+    num::{NonZeroU32, NonZeroU8},
+};
 
 use crate::{EncodingError, Format, ImageView, Progress, Size};
 
@@ -493,25 +496,27 @@ impl EncodingSupport {
     ///
     /// ```
     /// # use dds::*;
+    /// # use std::num::NonZeroU32;
     /// let format = Format::NV12;
     /// let encoding = format.encoding_support().unwrap();
     ///
     /// assert_eq!(
     ///     encoding.size_multiple(),
-    ///     Some(Size {
-    ///         width: 2,
-    ///         height: 2,
-    ///     })
+    ///     Some((NonZeroU32::new(2).unwrap(), NonZeroU32::new(2).unwrap()))
     /// );
     /// assert_eq!(encoding.supports_size(Size::new(2, 2)), true);
     /// assert_eq!(encoding.supports_size(Size::new(3, 2)), false);
     /// ```
-    pub const fn size_multiple(&self) -> Option<Size> {
+    pub const fn size_multiple(&self) -> Option<(NonZeroU32, NonZeroU32)> {
         if let Some((w, h)) = self.size_multiple {
-            Some(Size {
-                width: w.get() as u32,
-                height: h.get() as u32,
-            })
+            if let (Some(w), Some(h)) = (
+                NonZeroU32::new(w.get() as u32),
+                NonZeroU32::new(h.get() as u32),
+            ) {
+                Some((w, h))
+            } else {
+                unreachable!()
+            }
         } else {
             None
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
+use std::num::NonZeroU32;
+
 use crate::{
     header::{DxgiFormat, FourCC, Header},
-    Format, Size,
+    Format,
 };
 
 #[derive(Debug)]
@@ -297,7 +299,7 @@ impl std::error::Error for HeaderError {
 #[non_exhaustive]
 pub enum EncodingError {
     UnsupportedFormat(Format),
-    InvalidSize(Size),
+    InvalidSize(NonZeroU32, NonZeroU32),
     /// Returned by [`crate::encode()`] when the user tries to write a surface
     /// with width or height of 0.
     EmptySurface,
@@ -323,12 +325,8 @@ impl std::fmt::Display for EncodingError {
             EncodingError::UnsupportedFormat(format) => {
                 write!(f, "Unsupported format: {:?}", format)
             }
-            EncodingError::InvalidSize(size) => {
-                write!(
-                    f,
-                    "Size is not a multiple of {}x{}",
-                    size.width, size.height
-                )
+            EncodingError::InvalidSize(width, height) => {
+                write!(f, "Size is not a multiple of {width}x{height}")
             }
             EncodingError::EmptySurface => write!(f, "Surface has a width or height of 0"),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use crate::{
     header::{DxgiFormat, FourCC, Header},
-    Format, SizeMultiple,
+    Format, Size,
 };
 
 #[derive(Debug)]
@@ -297,7 +297,7 @@ impl std::error::Error for HeaderError {
 #[non_exhaustive]
 pub enum EncodingError {
     UnsupportedFormat(Format),
-    InvalidSize(SizeMultiple),
+    InvalidSize(Size),
     /// Returned by [`crate::encode()`] when the user tries to write a surface
     /// with width or height of 0.
     EmptySurface,
@@ -324,7 +324,11 @@ impl std::fmt::Display for EncodingError {
                 write!(f, "Unsupported format: {:?}", format)
             }
             EncodingError::InvalidSize(size) => {
-                write!(f, "Size is not a multiple of {:?}", size)
+                write!(
+                    f,
+                    "Size is not a multiple of {}x{}",
+                    size.width, size.height
+                )
             }
             EncodingError::EmptySurface => write!(f, "Surface has a width or height of 0"),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,6 @@ mod resize;
 mod split;
 mod util;
 
-use std::num::NonZeroU8;
-
 pub use color::*;
 pub use decode::{decode, decode_rect, DecodeOptions};
 pub use decoder::*;
@@ -160,45 +158,10 @@ impl Size {
             height: util::get_mipmap_size(self.height, level).get(),
         }
     }
-
-    pub const fn is_multiple_of(&self, multiple: SizeMultiple) -> bool {
-        self.width % multiple.width_multiple.get() as u32 == 0
-            && self.height % multiple.height_multiple.get() as u32 == 0
-    }
-    pub const fn round_down_to_multiple(&self, multiple: SizeMultiple) -> Self {
-        Self {
-            width: self.width - self.width % multiple.width_multiple.get() as u32,
-            height: self.height - self.height % multiple.height_multiple.get() as u32,
-        }
-    }
 }
 impl From<(u32, u32)> for Size {
     fn from((width, height): (u32, u32)) -> Self {
         Self { width, height }
-    }
-}
-
-// TODO: Rethink this API
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SizeMultiple {
-    pub width_multiple: NonZeroU8,
-    pub height_multiple: NonZeroU8,
-}
-impl SizeMultiple {
-    pub const ONE: Self = Self::new(1, 1);
-    // TODO: rename
-    pub const M2_2: Self = Self::new(2, 2);
-
-    const fn new(width_multiple: u8, height_multiple: u8) -> Self {
-        if let Some(width_multiple) = NonZeroU8::new(width_multiple) {
-            if let Some(height_multiple) = NonZeroU8::new(height_multiple) {
-                return Self {
-                    width_multiple,
-                    height_multiple,
-                };
-            }
-        }
-        panic!("SizeMultiple must be non-zero");
     }
 }
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -88,10 +88,7 @@ fn encode_base() {
                 // round down to the nearest multiple
                 let w_mul = size_multiple.width;
                 let h_mul = size_multiple.height;
-                size = Size::new(
-                    (size.width / w_mul) * w_mul,
-                    (size.height / h_mul) * h_mul,
-                );
+                size = Size::new((size.width / w_mul) * w_mul, (size.height / h_mul) * h_mul);
             }
         };
 

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -84,7 +84,15 @@ fn encode_base() {
     let test = |format: Format, dds_path: &Path| -> Result<String, Box<dyn std::error::Error>> {
         let mut size = base_u8.size;
         if let Some(support) = format.encoding_support() {
-            size = size.round_down_to_multiple(support.size_multiple());
+            if let Some(size_multiple) = support.size_multiple() {
+                // round down to the nearest multiple
+                let w_mul = size_multiple.width;
+                let h_mul = size_multiple.height;
+                size = Size::new(
+                    (size.width / w_mul) * w_mul,
+                    (size.height / h_mul) * h_mul,
+                );
+            }
         };
 
         let mut output = Vec::new();
@@ -577,7 +585,7 @@ fn encode_all_color_formats() {
 
     for &format in util::ALL_FORMATS {
         if let Some(support) = format.encoding_support() {
-            if support.size_multiple() != SizeMultiple::ONE {
+            if support.size_multiple().is_some() {
                 continue;
             }
         } else {

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -84,10 +84,10 @@ fn encode_base() {
     let test = |format: Format, dds_path: &Path| -> Result<String, Box<dyn std::error::Error>> {
         let mut size = base_u8.size;
         if let Some(support) = format.encoding_support() {
-            if let Some(size_multiple) = support.size_multiple() {
+            if let Some((w_mul, h_mul)) = support.size_multiple() {
                 // round down to the nearest multiple
-                let w_mul = size_multiple.width;
-                let h_mul = size_multiple.height;
+                let w_mul = w_mul.get();
+                let h_mul = h_mul.get();
                 size = Size::new((size.width / w_mul) * w_mul, (size.height / h_mul) * h_mul);
             }
         };

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -111,8 +111,8 @@ fn supported_formats_metadata() {
                     "❌".to_string()
                 };
 
-                let size_mul = if let Some(size_multiple) = encoding.size_multiple() {
-                    format!("{}x{}", size_multiple.width, size_multiple.height)
+                let size_mul = if let Some((w, h)) = encoding.size_multiple() {
+                    format!("{w}x{h}")
                 } else {
                     "".to_string()
                 };

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -111,12 +111,8 @@ fn supported_formats_metadata() {
                     "❌".to_string()
                 };
 
-                let size_multiple = encoding.size_multiple();
-                let size_mul = if size_multiple != SizeMultiple::ONE {
-                    format!(
-                        "{}x{}",
-                        size_multiple.width_multiple, size_multiple.height_multiple
-                    )
+                let size_mul = if let Some(size_multiple) = encoding.size_multiple() {
+                    format!("{}x{}", size_multiple.width, size_multiple.height)
                 } else {
                     "".to_string()
                 };

--- a/tests/progress.rs
+++ b/tests/progress.rs
@@ -69,7 +69,7 @@ fn track_progress() {
         let mut progress = Progress::new(&mut consume_progress);
 
         let mut header = Header::new_image(image.width(), image.height(), format);
-        if mipmaps && format.encoding_support().unwrap().size_multiple() == SizeMultiple::ONE {
+        if mipmaps && format.encoding_support().unwrap().size_multiple().is_none() {
             header = header.with_mipmaps();
         }
 
@@ -194,7 +194,7 @@ fn forward_progress() {
         let mut progress = Progress::new(&mut consume_progress);
 
         let mut header = Header::new_image(image.width(), image.height(), format);
-        if format.encoding_support().unwrap().size_multiple() == SizeMultiple::ONE {
+        if format.encoding_support().unwrap().size_multiple().is_none() {
             header = header.with_mipmaps();
         }
 


### PR DESCRIPTION
Resolves #33

This PR removes the public `SizeMultiple` type as well as the `Size` methods dealing with it. `EncodingSupport::size_multiple` now returns an `Option<(NonZeroU32, NonZeroU32)>`. I also implemented `EncodingSupport::supports_size` like I suggested in #33.