### PR TITLE
Specify `include` field in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,16 @@ repository = "https://github.com/image-rs/image-dds"
 homepage = "https://github.com/image-rs/image-dds"
 categories = ["multimedia::images", "multimedia::encoding"]
 
+include = [
+	"src/",
+	"benches/",
+	"README.md",
+	"CHANGELOG.md",
+	"supported-formats.md",
+	"LICENSE-APACHE",
+	"LICENSE-MIT",
+]
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This adds an `include` field to only publish the files that are strictly necessary. 

I specifically omitted the `tests` and `test-data` folders, because the test require around 8MB (compressed) of data. I don't want the published package to include all that.