### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Release 0.1.0 (2025-04-22)
+
+Initial release of the project.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## Release 0.1.0 (2025-04-22)
+## Release 0.1.0 (2025-04-30)
 
 Initial release of the project.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.63.0"
 
 license = "MIT OR Apache-2.0"
 description = "DDS de/encoder written in 100% safe Rust"
-authors = ["Michael Schmidt"]
+authors = ["The image-rs Developers"]
 
 repository = "https://github.com/image-rs/image-dds"
 homepage = "https://github.com/image-rs/image-dds"


### PR DESCRIPTION
This PR adds the changelog for v0.1.0. Since it's the first version, I just said "initial release."