### PR TITLE
Reduce the number of generic instantiations for ASTC

### DIFF
--- a/src/decode/astc.rs
+++ b/src/decode/astc.rs
@@ -25,7 +25,7 @@ where
         );
 
         let width = footprint.block_width() as usize;
-        astc_decode::astc_decode_block(bytes, footprint, |x, y, [r, g, b, a]| {
+        astc_decode::astc_decode_block(bytes, footprint, move |x, y, [r, g, b, a]| {
             out[y as usize * width + x as usize] = [
                 NormConvert::to(r),
                 NormConvert::to(g),

--- a/src/decode/astc.rs
+++ b/src/decode/astc.rs
@@ -8,17 +8,39 @@ use crate::{Channels, ColorFormat, NormConvert, WithPrecision};
 
 fn decode_astc_block<const PIXELS: usize, T: Default + Copy>(
     block_size: (usize, usize),
-    map_fn: impl Fn(u8) -> T,
-) -> impl Fn([u8; 16]) -> [[T; 4]; PIXELS] {
+) -> impl Fn([u8; 16]) -> [[T; 4]; PIXELS]
+where
+    u8: NormConvert<T>,
+{
+    // The inner function isn't generic over PIXELS. This brings down the
+    // number of instantiations of astc_decode::astc_decode_block from 14*3=42
+    // to 3. This saves around 110KiB in the final binary.
+    fn decode_into<T>(bytes: &[u8; 16], footprint: astc_decode::Footprint, out: &mut [[T; 4]])
+    where
+        u8: NormConvert<T>,
+    {
+        debug_assert_eq!(
+            footprint.block_width() as usize * footprint.block_height() as usize,
+            out.len()
+        );
+
+        let width = footprint.block_width() as usize;
+        astc_decode::astc_decode_block(bytes, footprint, |x, y, [r, g, b, a]| {
+            out[y as usize * width + x as usize] = [
+                NormConvert::to(r),
+                NormConvert::to(g),
+                NormConvert::to(b),
+                NormConvert::to(a),
+            ];
+        });
+    }
+
     debug_assert_eq!(PIXELS, block_size.0 * block_size.1);
     let footprint = astc_decode::Footprint::new(block_size.0 as u32, block_size.1 as u32);
 
     move |bytes| {
         let mut block = [[T::default(); 4]; PIXELS];
-        let width = footprint.block_width() as usize;
-        astc_decode::astc_decode_block(&bytes, footprint, |x, y, [r, g, b, a]| {
-            block[y as usize * width + x as usize] = [map_fn(r), map_fn(g), map_fn(b), map_fn(a)];
-        });
+        decode_into(&bytes, footprint, &mut block);
         block
     }
 }
@@ -38,10 +60,7 @@ macro_rules! astc_decoder {
             stride: usize,
             range: PixelRange,
         ) {
-            let f = decode_astc_block::<BLOCK_PIXELS, $out>(
-                (BLOCK_WIDTH, BLOCK_HEIGHT),
-                NormConvert::to,
-            );
+            let f = decode_astc_block::<BLOCK_PIXELS, $out>((BLOCK_WIDTH, BLOCK_HEIGHT));
             general_process_blocks::<
                 BLOCK_WIDTH,
                 BLOCK_HEIGHT,


### PR DESCRIPTION
The closure passed into `astc_decode::astc_decode_block` was unintentionally generic over the block size. This meant that `astc_decode::astc_decode_block` was instantiated 42 times.

This PR fixes this oversight and reduces the number of instantiations down to 3. This saves around 110KiB of binary size.