### PR TITLE
Remove exact version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-astc-decode = "=0.3.1"
+astc-decode = "0.3.1"
 bitflags = "2.4.0"
 glam = "0.25.0"
 resize = { version = "0.8.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
In Cargo, a version requirement of `foo = "0.3.1"` actually means "version 0.3.1 or any later semver compatible version" while `foo = "=0.3.1"` means "exactly version 0.3.1". As a result, specifying exact versions risks causing issues for users. If one crate requires `foo = "0.3.2"` of a crate and a different one requires `foo = "=0.3.1"`, then users _cannot_ use both crates: Cargo will refuse to compile because the two ranges are semver compatible but there's no version that can satisfy both.