### PR TITLE
Add support for row pitch in `ImageView` and `ImageViewMut`

### DIFF
--- a/src/decode/astc.rs
+++ b/src/decode/astc.rs
@@ -84,13 +84,12 @@ macro_rules! astc_decoder {
                     process_blocks,
                 )
             },
-            |RArgs(r, out, row_pitch, rect, context)| {
+            |RArgs(r, out, offset, context)| {
                 for_each_block_rect_untyped::<BLOCK_WIDTH, BLOCK_HEIGHT, BYTES_PER_BLOCK>(
                     r,
                     out,
-                    row_pitch,
+                    offset,
                     context,
-                    rect,
                     NATIVE_COLOR,
                     process_blocks,
                 )

--- a/src/decode/bc.rs
+++ b/src/decode/bc.rs
@@ -39,13 +39,12 @@ macro_rules! underlying {
                     process_blocks,
                 )
             },
-            |RArgs(r, out, row_pitch, rect, context)| {
+            |RArgs(r, out, offset, context)| {
                 for_each_block_rect_untyped::<4, 4, BYTES_PER_BLOCK>(
                     r,
                     out,
-                    row_pitch,
+                    offset,
                     context,
-                    rect,
                     NATIVE_COLOR,
                     process_blocks,
                 )

--- a/src/decode/bi_planar.rs
+++ b/src/decode/bi_planar.rs
@@ -42,13 +42,12 @@ macro_rules! underlying {
             |Args(r, out, context)| {
                 for_each_bi_planar(r, out, context, NATIVE_COLOR, INFO, process_bi_planar)
             },
-            |RArgs(r, out, row_pitch, rect, context)| {
+            |RArgs(r, out, offset, context)| {
                 for_each_bi_planar_rect(
                     r,
                     out,
-                    row_pitch,
+                    offset,
                     context,
-                    rect,
                     NATIVE_COLOR,
                     INFO,
                     process_bi_planar,

--- a/src/decode/decoder.rs
+++ b/src/decode/decoder.rs
@@ -1,18 +1,26 @@
 use std::io::{Read, Seek};
 use std::mem::size_of;
 
-use crate::{
-    Channels, ColorFormat, ColorFormatSet, DecodingError, ImageViewMut, Precision, Rect, Size,
-};
+use crate::{Channels, ColorFormat, ColorFormatSet, DecodingError, ImageViewMut, Precision, Size};
 
 use super::DecodeOptions;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Offset {
+    pub x: u32,
+    pub y: u32,
+}
+impl Offset {
+    pub const fn new(x: u32, y: u32) -> Self {
+        Self { x, y }
+    }
+}
 
 pub(crate) type DecodeFn = fn(args: Args) -> Result<(), DecodingError>;
 pub(crate) type DecodeRectFn = fn(args: RArgs) -> Result<(), DecodingError>;
 
 pub(crate) struct DecodeContext {
-    pub color: ColorFormat,
-    pub size: Size,
+    pub surface_size: Size,
     pub memory_limit: usize,
 }
 impl DecodeContext {
@@ -51,75 +59,18 @@ impl<T: Read + Seek> ReadSeek for T {}
 /// The "fix" is to wrap all mutable references in a struct so that compiler
 /// can't see them in the type signature of the function pointer anymore. Truly
 /// silly, and thankfully not necessary on never compiler versions.
-pub(crate) struct Args<'a, 'b>(pub &'a mut dyn Read, pub &'b mut [u8], pub DecodeContext);
-impl<'a, 'b> Args<'a, 'b> {
-    pub fn new(
-        reader: &'a mut dyn Read,
-        output: &'b mut [u8],
-        context: DecodeContext,
-    ) -> Result<Self, DecodingError> {
-        let bytes_per_pixel = context.color.bytes_per_pixel() as u64;
-        assert_eq!(
-            output.len() as u64,
-            context.size.pixels().saturating_mul(bytes_per_pixel)
-        );
-
-        Ok(Self(reader, output, context))
-    }
-}
+pub(crate) struct Args<'a, 'b>(
+    pub &'a mut dyn Read,
+    pub ImageViewMut<'b>,
+    pub DecodeContext,
+);
 
 pub(crate) struct RArgs<'a, 'b>(
     pub &'a mut dyn ReadSeek,
-    pub &'b mut [u8],
-    pub usize,
-    pub Rect,
+    pub ImageViewMut<'b>,
+    pub Offset,
     pub DecodeContext,
 );
-impl<'a, 'b> RArgs<'a, 'b> {
-    pub fn new(
-        reader: &'a mut dyn ReadSeek,
-        output: &'b mut [u8],
-        row_pitch: usize,
-        rect: Rect,
-        context: DecodeContext,
-    ) -> Result<Self, DecodingError> {
-        // Check that the rect is within the bounds of the image.
-        if !rect.is_within_bounds(context.size) {
-            return Err(DecodingError::RectOutOfBounds);
-        }
-
-        // Check row pitch
-        let min_row_pitch = if rect.size().is_empty() {
-            0
-        } else {
-            usize::saturating_mul(
-                rect.width as usize,
-                context.color.bytes_per_pixel() as usize,
-            )
-        };
-        if row_pitch < min_row_pitch {
-            return Err(DecodingError::RowPitchTooSmall {
-                required_minimum: min_row_pitch,
-            });
-        }
-
-        // Check that the buffer is long enough
-        // saturate to usize::MAX on overflow
-        let required_bytes = if rect.size().is_empty() {
-            0
-        } else {
-            usize::saturating_mul(row_pitch, (rect.height - 1) as usize)
-                .saturating_add(min_row_pitch)
-        };
-        if output.len() < required_bytes {
-            return Err(DecodingError::RectBufferTooSmall {
-                required_minimum: required_bytes,
-            });
-        }
-
-        Ok(Self(reader, output, row_pitch, rect, context))
-    }
-}
 
 /// Contains decode functions directly. These functions can be used as is.
 pub(crate) struct Decoder {
@@ -219,21 +170,20 @@ impl DecoderSet {
     pub fn decode(
         &self,
         reader: &mut dyn Read,
-        mut image: ImageViewMut,
+        image: ImageViewMut,
         options: &DecodeOptions,
     ) -> Result<(), DecodingError> {
         let color = image.color();
         let size = image.size();
 
-        let args = Args::new(
+        let args = Args(
             reader,
-            image.data(),
+            image,
             DecodeContext {
-                color,
-                size,
+                surface_size: size,
                 memory_limit: options.memory_limit,
             },
-        )?;
+        );
 
         // never decode empty images
         if size.is_empty() {
@@ -251,33 +201,27 @@ impl DecoderSet {
         (decoder.decode_fn)(args)
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn decode_rect(
         &self,
-        color: ColorFormat,
         reader: &mut dyn ReadSeek,
-        size: Size,
-        rect: Rect,
-        output: &mut [u8],
-        row_pitch: usize,
+        image: ImageViewMut,
+        offset: Offset,
+        surface_size: Size,
         options: &DecodeOptions,
     ) -> Result<(), DecodingError> {
-        let args = RArgs::new(
+        let color = image.color();
+
+        debug_assert!(!image.size().is_empty());
+
+        let args = RArgs(
             reader,
-            output,
-            row_pitch,
-            rect,
+            image,
+            offset,
             DecodeContext {
-                color,
-                size,
+                surface_size,
                 memory_limit: options.memory_limit,
             },
-        )?;
-
-        // never decode empty rectangles
-        if rect.size().is_empty() {
-            return Ok(());
-        }
+        );
 
         let decoder = self.get_decoder(color);
         (decoder.decode_rect_fn)(args)

--- a/src/decode/sub_sampled.rs
+++ b/src/decode/sub_sampled.rs
@@ -41,13 +41,12 @@ macro_rules! underlying {
                     process_blocks,
                 )
             },
-            |RArgs(r, out, row_pitch, rect, context)| {
+            |RArgs(r, out, offset, context)| {
                 for_each_block_rect_untyped::<2, 1, BYTES_PER_BLOCK>(
                     r,
                     out,
-                    row_pitch,
+                    offset,
                     context,
-                    rect,
                     NATIVE_COLOR,
                     process_blocks,
                 )
@@ -94,13 +93,12 @@ macro_rules! r1 {
                     process_blocks,
                 )
             },
-            |RArgs(r, out, row_pitch, rect, context)| {
+            |RArgs(r, out, offset, context)| {
                 for_each_block_rect_untyped::<8, 1, 1>(
                     r,
                     out,
-                    row_pitch,
+                    offset,
                     context,
-                    rect,
                     NATIVE_COLOR,
                     process_blocks,
                 )

--- a/src/encode/bi_planar.rs
+++ b/src/encode/bi_planar.rs
@@ -8,7 +8,8 @@ use super::{
 };
 use crate::{
     cast::{self, ToLe},
-    convert_to_rgba_f32, util, yuv10, yuv16, yuv8, EncodingError, Report,
+    encode::write_util::for_each_f32_rgba_rows,
+    util, yuv10, yuv16, yuv8, EncodingError, Report,
 };
 
 #[allow(clippy::type_complexity)]
@@ -20,16 +21,14 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
     const BLOCK_HEIGHT: usize = 2;
 
     let Args {
-        data,
-        color,
+        image,
         writer,
-        width,
-        height,
         options,
         mut progress,
         ..
     } = args;
-    let bytes_per_pixel = color.bytes_per_pixel() as usize;
+    let width = image.width() as usize;
+    let height = image.height() as usize;
 
     if width % BLOCK_WIDTH != 0 || height % BLOCK_HEIGHT != 0 {
         return Err(EncodingError::InvalidSize(
@@ -38,36 +37,25 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
         ));
     }
 
-    let mut intermediate_buffer = vec![[0_f32; 4]; width * BLOCK_HEIGHT];
     let mut plane1_buffer = vec![P1::default(); width * BLOCK_HEIGHT];
     let mut plane2: Vec<P2> = Vec::new();
 
-    let row_pitch = width * bytes_per_pixel;
     let line_group_count = util::div_ceil(height, BLOCK_HEIGHT);
     let report_frequency = util::div_ceil(1024 * 1024, width * BLOCK_HEIGHT);
-    for (group_index, line_group) in data.chunks(row_pitch * BLOCK_HEIGHT).enumerate() {
+    let mut group_index = 0;
+    for_each_f32_rgba_rows(image, BLOCK_HEIGHT, |rows| {
         if group_index % report_frequency == 0 {
             // occasionally report progress
             progress.report(group_index as f32 / line_group_count as f32);
         }
-
-        debug_assert!(line_group.len() % row_pitch == 0);
-        let rows_in_group = line_group.len() / row_pitch;
-
-        // fill the intermediate buffer
-        convert_to_rgba_f32(
-            color,
-            line_group,
-            &mut intermediate_buffer[..rows_in_group * width],
-        );
+        group_index += 1;
 
         // handle full blocks
         for macro_x in 0..width / BLOCK_WIDTH {
             let mut block = [[0_f32; 4]; 4];
             for y in 0..BLOCK_HEIGHT {
                 for x in 0..BLOCK_WIDTH {
-                    block[y * BLOCK_WIDTH + x] =
-                        intermediate_buffer[y * width + macro_x * BLOCK_WIDTH + x];
+                    block[y * BLOCK_WIDTH + x] = rows[y * width + macro_x * BLOCK_WIDTH + x];
                 }
             }
 
@@ -82,8 +70,8 @@ fn bi_planar_universal<P1: ToLe + cast::Castable + Default + Copy, P2: ToLe + ca
         }
 
         P1::to_le(&mut plane1_buffer);
-        writer.write_all(cast::as_bytes(&plane1_buffer[..rows_in_group * width]))?;
-    }
+        writer.write_all(cast::as_bytes(&plane1_buffer))
+    })?;
 
     P2::to_le(&mut plane2);
     writer.write_all(cast::as_bytes(&plane2))?;

--- a/src/encode/sub_sampled.rs
+++ b/src/encode/sub_sampled.rs
@@ -36,15 +36,15 @@ where
     EncodedBlock: Default + Copy + cast::ToLe + cast::Castable,
 {
     let Args {
-        data,
-        color,
+        image,
         writer,
-        width,
-        height,
         mut progress,
         ..
     } = args;
+    let color = image.color();
     let bytes_per_pixel = color.bytes_per_pixel() as usize;
+    let width = image.width() as usize;
+    let height = image.height() as usize;
 
     assert!(block_width >= 2);
 
@@ -58,7 +58,7 @@ where
     let chunk_count = height * util::div_ceil(width * bytes_per_pixel, chunk_size);
     let mut chunk_index: usize = 0;
 
-    for (y_index, y_line) in data.chunks(width * bytes_per_pixel).enumerate() {
+    for (y_index, y_line) in image.rows().enumerate() {
         debug_assert!(y_line.len() == width * bytes_per_pixel);
 
         for chunk in y_line.chunks(chunk_size) {

--- a/src/encode/write_util.rs
+++ b/src/encode/write_util.rs
@@ -1,0 +1,116 @@
+use crate::{convert_to_rgba_f32, ImageView};
+
+/// Converts the given images to f32 RGBA, `block_height` rows at a time. The
+/// closure `f` is called with a mutable slice of `[[f32; 4]]` that contains
+/// `block_height` rows of the image, each row containing `width` pixels.
+///
+/// If the image height is not a multiple of `block_height`, the implementation
+/// will fill the missing rows by duplicating previous rows.
+pub(crate) fn for_each_f32_rgba_rows<E>(
+    image: ImageView,
+    block_height: usize,
+    mut f: impl FnMut(&mut [[f32; 4]]) -> Result<(), E>,
+) -> Result<(), E> {
+    debug_assert!(block_height != 0);
+
+    let color = image.color();
+    let width = image.width() as usize;
+    let height = image.height() as usize;
+
+    // this is the one and only buffer we need
+    let mut intermediate_buffer = vec![[0_f32; 4]; width * block_height];
+
+    // go through the image row by row, convert it to f32 RGBA, and then
+    // pass it to the closure
+    let mut rows = image.rows();
+
+    let full_blocks = height / block_height;
+    for _ in 0..full_blocks {
+        // fill the intermediate buffer
+        for i in 0..block_height {
+            convert_to_rgba_f32(
+                color,
+                rows.next().expect("Image has too few rows"),
+                &mut intermediate_buffer[i * width..(i + 1) * width],
+            );
+        }
+
+        f(intermediate_buffer.as_mut_slice())?;
+    }
+
+    let rest_blocks = height % block_height;
+    if rest_blocks > 0 {
+        // fill intermediate buffer with the remaining rows
+        for i in 0..rest_blocks {
+            convert_to_rgba_f32(
+                color,
+                rows.next().expect("Image has too few rows"),
+                &mut intermediate_buffer[i * width..(i + 1) * width],
+            );
+        }
+        debug_assert!(rows.next().is_none());
+
+        // fill missing rows
+        for i in rest_blocks..block_height {
+            // copy the first line to fill the rest
+            // TODO: maybe change this to fill with the last line?
+            intermediate_buffer.copy_within(..width, i * width);
+        }
+
+        f(intermediate_buffer.as_mut_slice())?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn for_each_chunk<T, E>(
+    image: ImageView,
+    buffer: &mut [T],
+    buffer_elements_per_pixel: usize,
+    mut copy_to_buffer: impl FnMut(&[u8], &mut [T]),
+    mut process_chunk: impl FnMut(&mut [T]) -> Result<(), E>,
+) -> Result<(), E> {
+    let buffer_pixels = buffer.len() / buffer_elements_per_pixel;
+    let buffer = &mut buffer[..buffer_pixels * buffer_elements_per_pixel];
+    let bytes_per_pixel = image.color().bytes_per_pixel() as usize;
+
+    if image.is_contiguous() {
+        // Since the image is contiguous, we can process it in chunks directly
+        for chunk in image.data().chunks(buffer_pixels * bytes_per_pixel) {
+            let pixels = chunk.len() / bytes_per_pixel;
+            let chunk_buffer = &mut buffer[..pixels * buffer_elements_per_pixel];
+            copy_to_buffer(chunk, chunk_buffer);
+            process_chunk(chunk_buffer)?;
+        }
+    } else {
+        // With non-contiguous images, we need to build up the buffer from
+        // multiple rows
+        let mut fill_pixels = 0;
+        for mut row in image.rows() {
+            while !row.is_empty() {
+                if fill_pixels == buffer_pixels {
+                    // Buffer is full, flush it
+                    process_chunk(buffer)?;
+                    fill_pixels = 0;
+                }
+
+                debug_assert!(row.len() % bytes_per_pixel == 0);
+                let row_pixels = row.len() / bytes_per_pixel;
+                let write_pixels = row_pixels.min(buffer_pixels - fill_pixels);
+                copy_to_buffer(
+                    &row[..write_pixels * bytes_per_pixel],
+                    &mut buffer[fill_pixels * buffer_elements_per_pixel
+                        ..(fill_pixels + write_pixels) * buffer_elements_per_pixel],
+                );
+                fill_pixels += write_pixels;
+                row = &row[write_pixels * bytes_per_pixel..];
+            }
+        }
+        if fill_pixels > 0 {
+            // Flush the remaining data in the buffer
+            process_chunk(&mut buffer[..fill_pixels * buffer_elements_per_pixel])?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,18 +88,10 @@ pub enum DecodingError {
     /// When decoding a rectangle, the rectangle is out of bounds of the size
     /// of the image.
     RectOutOfBounds,
-    /// When decoding a rectangle, the row pitch is too small.
-    ///
-    /// A row pitch must be at least `color.bytes_per_pixel() * rect.width` bytes.
-    RowPitchTooSmall {
-        required_minimum: usize,
-    },
-    /// When decoding a rectangle, the buffer is too small.
-    ///
-    /// A buffer much have at least `row_pitch * rect.height` bytes.
-    RectBufferTooSmall {
-        required_minimum: usize,
-    },
+    /// Returned by [`Decoder::read_surface_rect`](crate::Decoder::read_surface_rect)
+    /// and [`decode()`](crate::decode()) when the size of the image does not
+    /// match the size of the rectangle.
+    UnexpectedRectSize,
 
     /// Returned by [`Decoder::read_surface`](crate::Decoder::read_surface)
     /// when the user tries to decode a surface into an image that is not the
@@ -132,17 +124,8 @@ impl std::fmt::Display for DecodingError {
             DecodingError::RectOutOfBounds => {
                 write!(f, "Rectangle is out of bounds of the image size")
             }
-            DecodingError::RowPitchTooSmall { required_minimum } => {
-                write!(
-                    f,
-                    "Row pitch too small: Must be at least `color.bytes_per_pixel() * rect.width` == {required_minimum} bytes"
-                )
-            }
-            DecodingError::RectBufferTooSmall { required_minimum } => {
-                write!(
-                    f,
-                    "Buffer too small for rectangle: required at least {required_minimum} bytes"
-                )
+            DecodingError::UnexpectedRectSize => {
+                write!(f, "Unexpected rectangle size")
             }
             DecodingError::UnexpectedSurfaceSize => {
                 write!(f, "Unexpected surface size")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,18 +349,68 @@ pub struct ImageViewMut<'a> {
     data: &'a mut [u8],
     size: Size,
     color: ColorFormat,
+    row_pitch: usize,
 }
 impl<'a> ImageViewMut<'a> {
-    /// Creates a new image view from the given data, size, and color format.
+    /// Creates a new contiguous image view from the given data, size, and color
+    /// format.
     ///
     /// The data must be the correct size for the given size and color format.
     /// If `data.len() != size.pixels() * color.bytes_per_pixel()`,
     /// then `None` is returned.
-    pub fn new(data: &'a mut [u8], size: Size, color: ColorFormat) -> Option<Self> {
+    pub fn new(data: &'a mut [u8], mut size: Size, color: ColorFormat) -> Option<Self> {
+        if size.is_empty() {
+            size = Size::new(0, 0);
+        }
+
         if data.len() as u64 != size.pixels().saturating_mul(color.bytes_per_pixel() as u64) {
             return None;
         }
-        Some(Self { data, size, color })
+        let row_pitch = size.width as usize * color.bytes_per_pixel() as usize;
+
+        Some(Self {
+            data,
+            size,
+            color,
+            row_pitch,
+        })
+    }
+    /// Creates a new image view from the given data, row pitch, size, and color
+    /// format.
+    ///
+    /// The data and row pitch must be the correct size for the given size and
+    /// color format. If `row_pitch < width * color.bytes_per_pixel()` or the
+    /// data length is too short, then `None` will be returned.
+    ///
+    /// Note: The data slice will be truncated to the exact addressable length
+    /// based on row pitch and size.
+    pub fn new_with(
+        data: &'a mut [u8],
+        mut row_pitch: usize,
+        mut size: Size,
+        color: ColorFormat,
+    ) -> Option<Self> {
+        if size.is_empty() {
+            size = Size::new(0, 0);
+            row_pitch = 0;
+        }
+
+        let bytes_per_row = size.width as usize * color.bytes_per_pixel() as usize;
+        if row_pitch < bytes_per_row {
+            return None;
+        }
+
+        let addressable_len = row_pitch * size.height.saturating_sub(1) as usize + bytes_per_row;
+        if data.len() < addressable_len {
+            return None;
+        }
+
+        Some(Self {
+            data: &mut data[..addressable_len],
+            size,
+            color,
+            row_pitch,
+        })
     }
 
     pub fn data(&mut self) -> &mut [u8] {
@@ -380,8 +430,89 @@ impl<'a> ImageViewMut<'a> {
     pub fn color(&self) -> ColorFormat {
         self.color
     }
+
     pub fn row_pitch(&self) -> usize {
-        self.size.width as usize * self.color.bytes_per_pixel() as usize
+        self.row_pitch
+    }
+    pub(crate) fn bytes_per_row(&self) -> usize {
+        self.width() as usize * self.color.bytes_per_pixel() as usize
+    }
+    /// Returns `true` if the data is contiguous in memory.
+    pub fn is_contiguous(&self) -> bool {
+        self.row_pitch * self.height() as usize == self.data.len()
+    }
+
+    /// Returns a new image view that is a cropped version of this image.
+    ///
+    /// ## Panics
+    ///
+    /// If the rectangle is not within the bounds of the image size.
+    pub fn cropped(self, rect: Rect) -> Self {
+        assert!(
+            rect.is_within_bounds(self.size),
+            "Rectangle {:?} is not within bounds of size {:?}",
+            rect,
+            self.size
+        );
+
+        if rect.size().is_empty() {
+            return Self {
+                data: &mut [],
+                size: Size::new(0, 0),
+                color: self.color,
+                row_pitch: 0,
+            };
+        }
+
+        let bytes_per_row = rect.width as usize * self.color.bytes_per_pixel() as usize;
+        let start = (rect.y as usize * self.row_pitch)
+            + (rect.x as usize * self.color.bytes_per_pixel() as usize);
+        let end = start + ((rect.height - 1) as usize * self.row_pitch) + bytes_per_row;
+
+        Self {
+            data: &mut self.data[start..end],
+            size: rect.size(),
+            color: self.color,
+            row_pitch: self.row_pitch,
+        }
+    }
+    pub(crate) fn cropped_data(&mut self, rect: Rect) -> &mut [u8] {
+        assert!(
+            rect.is_within_bounds(self.size),
+            "Rectangle {:?} is not within bounds of size {:?}",
+            rect,
+            self.size
+        );
+
+        if rect.size().is_empty() {
+            return &mut [];
+        }
+
+        let bytes_per_row = rect.width as usize * self.color.bytes_per_pixel() as usize;
+        let start = (rect.y as usize * self.row_pitch)
+            + (rect.x as usize * self.color.bytes_per_pixel() as usize);
+        let end = start + ((rect.height - 1) as usize * self.row_pitch) + bytes_per_row;
+
+        &mut self.data[start..end]
+    }
+
+    pub(crate) fn rows_mut(&mut self) -> impl Iterator<Item = &'_ mut [u8]> {
+        let bytes_per_row = self.bytes_per_row();
+
+        self.data
+            .chunks_mut(self.row_pitch)
+            .map(move |row| &mut row[..bytes_per_row])
+    }
+    pub(crate) fn get_row(&mut self, y: usize) -> &mut [u8] {
+        let start = y * self.row_pitch;
+        let end = start + self.bytes_per_row();
+        &mut self.data[start..end]
+    }
+    pub(crate) fn get_row_range(&mut self, y: usize, height: usize) -> &mut [u8] {
+        debug_assert!(height > 0, "Height must be greater than 0");
+        let start = y * self.row_pitch;
+        let end = start + (height - 1) * self.row_pitch + self.bytes_per_row();
+        &mut self.data[start..end]
     }
 }
 

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,13 +1,13 @@
 use std::ops::Range;
 
-use crate::{Dithering, EncodeOptions, Format, ImageView, Size};
+use crate::{util, Dithering, EncodeOptions, Format, ImageView, Rect, Size};
 
 /// This implements the main logic for splitting a surface into lines.
 fn split_surface_into_lines(
     size: Size,
     format: Format,
     options: &EncodeOptions,
-) -> Option<Vec<Range<u32>>> {
+) -> Option<impl Iterator<Item = Range<u32>>> {
     if size.is_empty() {
         return None;
     }
@@ -38,15 +38,14 @@ fn split_surface_into_lines(
         u32::MAX as u64,
     ) as u32;
 
-    let mut lines = Vec::new();
-    let mut y: u32 = 0;
-    while y < size.height {
-        let end = y.saturating_add(group_height).min(size.height);
-        lines.push(y..end);
-        y = end;
-    }
+    let groups = util::div_ceil(size.height, group_height);
+    debug_assert!(groups >= 2);
 
-    Some(lines)
+    Some((0..groups).map(move |i| {
+        let start = i * group_height;
+        let end = ((i + 1) * group_height).min(size.height);
+        start..end
+    }))
 }
 
 pub struct SplitSurface<'a> {
@@ -71,26 +70,13 @@ impl<'a> SplitSurface<'a> {
 
     pub fn new(image: ImageView<'a>, format: Format, options: &EncodeOptions) -> Self {
         if let Some(ranges) = split_surface_into_lines(image.size(), format, options) {
-            let row_pitch = image.row_pitch();
-
-            let fragments = ranges
-                .into_iter()
-                .map(move |range| {
-                    let start = range.start as usize * row_pitch;
-                    let end = range.end as usize * row_pitch;
-                    let height = range.end - range.start;
-                    ImageView::new(
-                        &image.data[start..end],
-                        Size::new(image.width(), height),
-                        image.color,
-                    )
-                    .expect("invalid split")
-                })
-                .collect::<Vec<_>>()
-                .into_boxed_slice();
-
             Self {
-                fragments,
+                fragments: ranges
+                    .map(|range| {
+                        let height = range.end - range.start;
+                        image.cropped(Rect::new(0, range.start, image.width(), height))
+                    })
+                    .collect(),
                 format,
                 options: options.clone(),
             }

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -794,6 +794,72 @@ fn test_unaligned() {
     }
 }
 
+#[test]
+fn test_row_pitch() {
+    let backing_size = Size::new(256, 256);
+    let mut buffer = vec![0_u8; backing_size.pixels() as usize * 3];
+    util::create_rng().fill_bytes(&mut buffer);
+    let backing = ImageView::new(&buffer, backing_size, ColorFormat::RGB_U8).unwrap();
+
+    // I'm using prime numbers for the rect to make things as difficult as possible for the impl
+    let image = backing.cropped(Rect::new(13, 29, 89, 53));
+
+    // create a contiguous version of the image
+    let mut cont = vec![0_u8; image.size().pixels() as usize * 3];
+    let row_pitch = image.row_pitch();
+    let bytes_per_row = image.size().width as usize * image.color().bytes_per_pixel() as usize;
+    let data = image.data();
+    for y in 0..image.size().height as usize {
+        let src_row = &data[y * row_pitch..][..bytes_per_row];
+        let dst_row = &mut cont[y * bytes_per_row..][..bytes_per_row];
+        dst_row.copy_from_slice(src_row);
+    }
+    let cont_image = ImageView::new(&cont, image.size(), ColorFormat::RGB_U8).unwrap();
+
+    // // check that the two images are the same
+    // for (row, cont_row) in image.rows().zip(cont_image.rows()) {
+    //     assert_eq!(row, cont_row, "Row mismatch");
+    // }
+
+    for format in util::ALL_FORMATS.iter().copied() {
+        let Some(encoding) = format.encoding_support() else {
+            // encoding isn't supported
+            continue;
+        };
+
+        let mut size = image.size();
+        if !encoding.supports_size(size) {
+            let (w_mul, h_mul) = encoding.size_multiple().unwrap();
+            // round down to the nearest multiple
+            let w_mul = w_mul.get();
+            let h_mul = h_mul.get();
+            size = Size::new((size.width / w_mul) * w_mul, (size.height / h_mul) * h_mul);
+        }
+
+        let image = image.cropped(Rect::new(0, 0, size.width, size.height));
+        let cont_image = cont_image.cropped(Rect::new(0, 0, size.width, size.height));
+
+        let header = Header::new_image(size.width, size.height, format);
+
+        let mut cont_encoded = Vec::new();
+        let mut cont_encoder = Encoder::new(&mut cont_encoded, format, &header).unwrap();
+        cont_encoder.write_surface(cont_image).unwrap();
+        cont_encoder.finish().unwrap();
+
+        let mut non_cont_encoded = Vec::new();
+        let mut non_cont_encoder = Encoder::new(&mut non_cont_encoded, format, &header).unwrap();
+        non_cont_encoder.write_surface(image).unwrap();
+        non_cont_encoder.finish().unwrap();
+
+        assert_eq!(
+            cont_encoded.len(),
+            non_cont_encoded.len(),
+            "Failed for {format:?}"
+        );
+        assert!(cont_encoded == non_cont_encoded, "Failed for {format:?}");
+    }
+}
+
 mod errors {
     use super::*;
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -481,12 +481,9 @@ pub fn read_dds_rect_as_u8(
     let mut decoder = Decoder::new(file)?;
 
     let channels = to_png_compatible_channels(decoder.format().channels()).0;
-    let color = ColorFormat::new(channels, U8);
-    let bpp = color.bytes_per_pixel() as usize;
 
     let mut image = Image::new_empty(channels, rect.size());
-    let row_pitch = rect.width as usize * bpp;
-    decoder.read_surface_rect(image.as_bytes_mut(), row_pitch, rect, color)?;
+    decoder.read_surface_rect(image.view_mut(), rect)?;
 
     Ok((image, DdsInfo::from_decoder(&decoder)))
 }


### PR DESCRIPTION
Resolves #56

This PR adds support for row pitch in image views, which makes cropping and en/decoding image rectangles possible. This is quite useful, but was a pain to implement, because the assumption `row_pitch == width * bytes_per_pixel` as built into a lot of en/decoders. (It was such a pain that this PR is actually my third attempt at implementing this. But I'm quite happy that I did. The library is better for it.)

The performance impact of this feature is negligible. It's maybe 1% on average. Truth be told, there was a lot of noise in my benchmark timings, so 1% is my best guesstimate. However, I can say with certainty that there are no dramatic slowdowns.

Changes:
- Add a `row_pitch: usize` field to `ImageView` and `ImageViewMut`. This makes it possible to use `ImageView*` not just for whole (contiguous) images, but also for cropped sub-views of images.
- Added public `cropped` and `is_contiguous` functions to the view types.
- Changed the `decode_rect` and `Decoder::read_surface_rect` APIs to make use of row pitch support in `ImageViewMut`. I also updated `DecodeError` to remove 2 error variants that are no longer possible and to add 1 new one.
- Updated all encoder and decoder implementations to support row pitch. Despite adding functionality, some implementations actually got simpler, which is very nice.
- A few minor fly-by improvements.
