### PR TITLE
Handle allocation failure in decoders

### DIFF
--- a/src/decode/read_write.rs
+++ b/src/decode/read_write.rs
@@ -1191,9 +1191,7 @@ pub(crate) fn for_each_bi_planar(
 
     // Step 1: Read the entirety of plane 1
     let plain1_bytes_per_line = size.width as usize * info.plane1_element_size as usize;
-    let plane1_size = plain1_bytes_per_line * size.height as usize;
-    let mut plane1 = context.alloc_capacity(plane1_size)?;
-    read_exact_into(r, &mut plane1, plane1_size)?;
+    let plane1 = context.alloc_read(plain1_bytes_per_line * size.height as usize, r)?;
 
     // Step 2: Go through plane 2
     let uv_width = div_ceil(size.width, info.sub_sampling.0 as u32) as usize;
@@ -1254,9 +1252,7 @@ pub(crate) fn for_each_bi_planar_rect(
     // Step 1: Read the entirety of plane 1
     let plain1_bytes_per_line = size.width as usize * info.plane1_element_size as usize;
     util::io_skip_exact(r, plain1_bytes_per_line as u64 * rect.y as u64)?;
-    let plane1_bytes = plain1_bytes_per_line * rect.height as usize;
-    let mut plane1 = context.alloc_capacity(plane1_bytes)?;
-    read_exact_into(r, &mut plane1, plane1_bytes)?;
+    let plane1 = context.alloc_read(plain1_bytes_per_line * rect.height as usize, r)?;
     util::io_skip_exact(
         r,
         plain1_bytes_per_line as u64 * (size.height - rect.y - rect.height) as u64,
@@ -1327,26 +1323,6 @@ pub(crate) fn for_each_bi_planar_rect(
     }
 
     util::io_skip_exact(r, uv_after as u64 * uv_bytes_per_line as u64)?;
-
-    Ok(())
-}
-
-fn read_exact_into<R: Read + ?Sized>(
-    r: &mut R,
-    buf: &mut Vec<u8>,
-    count: usize,
-) -> Result<(), std::io::Error> {
-    buf.clear();
-    buf.reserve(count);
-
-    let take = count as u64;
-    let copied = std::io::copy(&mut r.take(take), buf)?;
-    if copied < take {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::UnexpectedEof,
-            "Failed to read enough bytes",
-        ));
-    }
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -117,7 +117,8 @@ pub enum DecodingError {
     /// when the user tries to read a DDS file that isn't a cube map.
     NotACubeMap,
 
-    /// The decoder has exceeded its memory limit.
+    /// The decoder has exceeded its memory limit or was unable to allocate
+    /// memory.
     MemoryLimitExceeded,
 
     Layout(LayoutError),

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -510,4 +510,32 @@ mod errors {
         let result = decode_dummy(Rect::new(2, 3, 0, 0), &mut [], 0);
         assert!(matches!(result, Ok(())));
     }
+
+    #[test]
+    fn out_of_memory() {
+        // To decode a P016 image, the decoder needs to allocate a buffer for
+        // the first plane. Creating an invalid image with width=2^32-1, each
+        // line of the first plane will require roughly 8GB of memory. Forcing
+        // the decoder to read 4096 lines, will cause it allocate 4096*8GB=32TB
+        // of memory, which should be OOM.
+        let output_size = Size::new(1, 4096);
+        let mut output_buffer = vec![0_u8; output_size.pixels() as usize];
+        let surface_size = Size::new(u32::MAX, output_size.height);
+
+        let mut options = DecodeOptions::default();
+        options.memory_limit = usize::MAX; // disable memory limit
+
+        let result = dds::decode_rect(
+            &mut std::io::empty(),
+            &mut output_buffer,
+            output_size.width as usize,
+            ColorFormat::GRAYSCALE_U8,
+            surface_size,
+            Rect::new(0, 0, output_size.width, output_size.height),
+            Format::P016,
+            &options,
+        );
+
+        assert!(matches!(result, Err(DecodingError::MemoryLimitExceeded)));
+    }
 }


### PR DESCRIPTION
Inspired by https://github.com/image-rs/image/pull/2514, I handled allocation failures in decoders. Instead of panicking on OOM, decoders will now return a `DecodingError::MemoryLimitExceeded`.

Decoders are only allowed to allocate via their context (which is how memory limits are enforced), so this wasn't too hard. The only real change is that I combined the old `alloc_capacity` and `read_exact_into` into `alloc_read`. The new method allocates a new vec and initializes using the reader. This has the advantage that decoders are never given a vec, which makes accidental allocations impossible.

The test for this will probably also unearth a few panics because of arithmetic overflow on 32-bit systems. Let's see.