### PR TITLE
Fix CI after `mismatched_lifetime_syntaxes` in Rust 1.89.0

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -57,7 +57,7 @@ impl SurfaceIterator {
         }
     }
 
-    pub fn current(&self) -> Option<SurfaceInfo> {
+    pub fn current(&self) -> Option<SurfaceInfo<'_>> {
         match self {
             Self::Texture(iter) => iter.current(),
             Self::Volume(iter) => iter.current(),
@@ -111,7 +111,7 @@ impl TextureSurfaceIterator {
         }
     }
 
-    fn current(&self) -> Option<SurfaceInfo> {
+    fn current(&self) -> Option<SurfaceInfo<'_>> {
         if self.current_index < self.len {
             let desc = self.first.get(self.current_level);
             debug_assert!(desc.is_some());
@@ -186,7 +186,7 @@ impl VolumeSurfaceIterator {
         }
     }
 
-    fn current(&self) -> Option<SurfaceInfo> {
+    fn current(&self) -> Option<SurfaceInfo<'_>> {
         let v = self.volume.get(self.current_level)?;
         debug_assert!(self.current_depth < v.depth());
         let desc = v.get_depth_slice(self.current_depth);


### PR DESCRIPTION
Rust 1.89.0 added the `mismatched_lifetime_syntaxes` lint, which emits new warnings. Since we error on warnings in CI, the new lint caused the CI to fail. This PR fixes the issues reported by the lint.