### PR TITLE
Reduce number of `as` casts

### DIFF
--- a/src/decode/astc.rs
+++ b/src/decode/astc.rs
@@ -7,7 +7,7 @@ use crate::{Channels, ColorFormat, NormConvert, WithPrecision};
 // helpers
 
 fn decode_astc_block<const PIXELS: usize, T: Default + Copy>(
-    block_size: (usize, usize),
+    block_size: (u8, u8),
 ) -> impl Fn([u8; 16]) -> [[T; 4]; PIXELS]
 where
     u8: NormConvert<T>,
@@ -35,7 +35,7 @@ where
         });
     }
 
-    debug_assert_eq!(PIXELS, block_size.0 * block_size.1);
+    debug_assert_eq!(PIXELS, block_size.0 as usize * block_size.1 as usize);
     let footprint = astc_decode::Footprint::new(block_size.0 as u32, block_size.1 as u32);
 
     move |bytes| {
@@ -47,9 +47,9 @@ where
 
 macro_rules! astc_decoder {
     ($out:ty, $block_w:literal, $block_h:literal) => {{
-        const BLOCK_WIDTH: usize = $block_w;
-        const BLOCK_HEIGHT: usize = $block_h;
-        const BLOCK_PIXELS: usize = BLOCK_WIDTH * BLOCK_HEIGHT;
+        const BLOCK_WIDTH: u8 = $block_w;
+        const BLOCK_HEIGHT: u8 = $block_h;
+        const BLOCK_PIXELS: usize = BLOCK_WIDTH as usize * BLOCK_HEIGHT as usize;
         const BYTES_PER_BLOCK: usize = 16;
         const CHANNELS: usize = 4;
         type OutPixel = [$out; CHANNELS];

--- a/src/decode/read_write.rs
+++ b/src/decode/read_write.rs
@@ -205,6 +205,7 @@ pub(crate) struct PixelRange {
     /// A non-empty range of the rows to decode. `rows.end` is at most `BLOCK_SIZE_Y`.
     pub rows: RowRange,
 }
+/// A non-empty range of rows of pixels.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RowRange {
     /// The start of the row range.
@@ -218,6 +219,8 @@ impl RowRange {
         Self { start, end }
     }
     /// Returns the number of rows in this range.
+    ///
+    /// This guaranteed to be at least 1.
     pub fn len(self) -> u8 {
         self.end - self.start
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,9 +163,12 @@
 //! multiple fragments for parallel encoding.
 
 #![forbid(unsafe_code)]
-#![warn(clippy::cast_possible_wrap)]
-#![warn(clippy::cast_sign_loss)]
-#![warn(clippy::cast_possible_truncation)]
+// TODO: warn once my cast improvements are merged
+#![allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation
+)]
 
 mod cast;
 mod color;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,9 @@
 //! into multiple fragments for parallel encoding.
 
 #![forbid(unsafe_code)]
+#![warn(clippy::cast_possible_wrap)]
+#![warn(clippy::cast_sign_loss)]
+#![warn(clippy::cast_possible_truncation)]
 
 mod cast;
 mod color;


### PR DESCRIPTION
I didn't like the large number of `as` casts the decoders were doing. Each one of the narrowing casts is a potential bug, so I:

1. Reduced the number of `as` casts by using more appropriate integer types. This typically means using `u32` for pixel positions and `u8` for block sizes.
2. Refactored code to only require widening `as` casts.
3. If narrowing casts are used, they can be proving to never truncate/wrap/loss sign using a simple value range analysis. I'm currently working on adding such a value range analysis to clippy. Once it's in, clippy should be able to prove most `as` casts correct, with only a few remaining.