### PR TITLE
More aggressive parallelization for BCn encoding

### DIFF
--- a/src/encode/bc.rs
+++ b/src/encode/bc.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::{
     bc1, bc4, bcn_util,
     encoder::{Args, Encoder, EncoderSet, Flags},
-    CompressionQuality, EncodeOptions, ErrorMetric, PreferredGroupSize,
+    CompressionQuality, EncodeOptions, ErrorMetric, PreferredFragmentSize,
 };
 
 fn block_universal<
@@ -140,9 +140,11 @@ fn concat_blocks(left: [u8; 8], right: [u8; 8]) -> [u8; 16] {
     out
 }
 
-const BC1_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(64 * 64, 16 * 16, 16 * 16);
-const BC3_GROUP_SIZE: PreferredGroupSize = BC1_GROUP_SIZE.combine(BC4_GROUP_SIZE);
-const BC4_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(64 * 64, 32 * 32, 8 * 8);
+const BC1_FRAGMENT_SIZE: PreferredFragmentSize =
+    PreferredFragmentSize::new(64 * 64, 16 * 16, 16 * 16);
+const BC3_FRAGMENT_SIZE: PreferredFragmentSize = BC1_FRAGMENT_SIZE.combine(BC4_FRAGMENT_SIZE);
+const BC4_FRAGMENT_SIZE: PreferredFragmentSize =
+    PreferredFragmentSize::new(64 * 64, 32 * 32, 8 * 8);
 
 // encoders
 
@@ -177,7 +179,7 @@ pub(crate) const BC1_UNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_ALL)
-.with_group_size(BC1_GROUP_SIZE)]);
+.with_fragment_size(BC1_FRAGMENT_SIZE)]);
 
 fn bc2_alpha(alpha: [f32; 16], options: &EncodeOptions) -> [u8; 8] {
     let mut indexes: u64 = 0;
@@ -215,7 +217,7 @@ pub(crate) const BC2_UNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_ALL)
-.with_group_size(BC1_GROUP_SIZE)]);
+.with_fragment_size(BC1_FRAGMENT_SIZE)]);
 
 pub(crate) const BC2_UNORM_PREMULTIPLIED_ALPHA: EncoderSet =
     EncoderSet::new_bc(&[Encoder::new_universal(|args| {
@@ -232,7 +234,7 @@ pub(crate) const BC2_UNORM_PREMULTIPLIED_ALPHA: EncoderSet =
         })
     })
     .add_flags(Flags::DITHER_ALL)
-    .with_group_size(BC1_GROUP_SIZE)]);
+    .with_fragment_size(BC1_FRAGMENT_SIZE)]);
 
 fn get_bc3_options(options: &EncodeOptions) -> (bc1::Bc1Options, bc4::Bc4Options) {
     let mut bc1_options = get_bc1_options(options);
@@ -256,7 +258,7 @@ pub(crate) const BC3_UNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_ALL)
-.with_group_size(BC3_GROUP_SIZE)]);
+.with_fragment_size(BC3_FRAGMENT_SIZE)]);
 
 pub(crate) const BC3_UNORM_PREMULTIPLIED_ALPHA: EncoderSet =
     EncoderSet::new_bc(&[Encoder::new_universal(|args| {
@@ -273,7 +275,7 @@ pub(crate) const BC3_UNORM_PREMULTIPLIED_ALPHA: EncoderSet =
         })
     })
     .add_flags(Flags::DITHER_ALL)
-    .with_group_size(BC3_GROUP_SIZE)]);
+    .with_fragment_size(BC3_FRAGMENT_SIZE)]);
 
 pub(crate) const BC3_UNORM_RXGB: EncoderSet =
     EncoderSet::new_bc(&[Encoder::new_universal(|args| {
@@ -300,7 +302,7 @@ pub(crate) const BC3_UNORM_RXGB: EncoderSet =
         })
     })
     .add_flags(Flags::DITHER_COLOR)
-    .with_group_size(BC3_GROUP_SIZE)]);
+    .with_fragment_size(BC3_FRAGMENT_SIZE)]);
 
 pub(crate) const BC3_UNORM_NORMAL: EncoderSet =
     EncoderSet::new_bc(&[Encoder::new_universal(|args| {
@@ -322,7 +324,7 @@ pub(crate) const BC3_UNORM_NORMAL: EncoderSet =
         })
     })
     .add_flags(Flags::DITHER_COLOR)
-    .with_group_size(BC3_GROUP_SIZE)]);
+    .with_fragment_size(BC3_FRAGMENT_SIZE)]);
 
 fn handle_bc4(data: &[[f32; 4]], row_pitch: usize, options: bc4::Bc4Options) -> [u8; 8] {
     let block = get_4x4_grayscale(data, row_pitch);
@@ -348,7 +350,7 @@ pub(crate) const BC4_UNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_COLOR)
-.with_group_size(BC4_GROUP_SIZE)]);
+.with_fragment_size(BC4_FRAGMENT_SIZE)]);
 
 pub(crate) const BC4_SNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_universal(|args| {
     block_universal::<4, 4, 8>(args, |data, row_pitch, options, out| {
@@ -358,7 +360,7 @@ pub(crate) const BC4_SNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_COLOR)
-.with_group_size(BC4_GROUP_SIZE)]);
+.with_fragment_size(BC4_FRAGMENT_SIZE)]);
 
 fn handle_bc5(data: &[[f32; 4]], row_pitch: usize, options: bc4::Bc4Options) -> [u8; 16] {
     let red_block = get_4x4_select_channel::<0>(data, row_pitch);
@@ -378,7 +380,7 @@ pub(crate) const BC5_UNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_COLOR)
-.with_group_size(BC4_GROUP_SIZE)]);
+.with_fragment_size(BC4_FRAGMENT_SIZE)]);
 
 pub(crate) const BC5_SNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_universal(|args| {
     block_universal::<4, 4, 16>(args, |data, row_pitch, options, out| {
@@ -388,4 +390,4 @@ pub(crate) const BC5_SNORM: EncoderSet = EncoderSet::new_bc(&[Encoder::new_unive
     })
 })
 .add_flags(Flags::DITHER_COLOR)
-.with_group_size(BC4_GROUP_SIZE)]);
+.with_fragment_size(BC4_FRAGMENT_SIZE)]);

--- a/src/encode/bc.rs
+++ b/src/encode/bc.rs
@@ -140,9 +140,9 @@ fn concat_blocks(left: [u8; 8], right: [u8; 8]) -> [u8; 16] {
     out
 }
 
-const BC1_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(256 * 256, 64 * 64, 64 * 64);
+const BC1_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(64 * 64, 16 * 16, 16 * 16);
 const BC3_GROUP_SIZE: PreferredGroupSize = BC1_GROUP_SIZE.combine(BC4_GROUP_SIZE);
-const BC4_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(512 * 256, 128 * 128, 8 * 8);
+const BC4_GROUP_SIZE: PreferredGroupSize = PreferredGroupSize::group(64 * 64, 32 * 32, 8 * 8);
 
 // encoders
 

--- a/src/encode/encoder.rs
+++ b/src/encode/encoder.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use super::{
-    Dithering, EncodeOptions, EncodingSupport, PreferredGroupSize, SizeMultiple, SIZE_MUL_2X2,
+    Dithering, EncodeOptions, EncodingSupport, PreferredFragmentSize, SizeMultiple, SIZE_MUL_2X2,
 };
 
 pub(crate) struct Args<'a, 'b, 'c, 'd> {
@@ -80,7 +80,7 @@ impl Flags {
 pub(crate) struct Encoder {
     pub color_formats: ColorFormatSet,
     pub flags: Flags,
-    group_size: PreferredGroupSize,
+    fragment_size: PreferredFragmentSize,
 
     pub encode: fn(Args) -> Result<(), EncodingError>,
 }
@@ -93,7 +93,7 @@ impl Encoder {
         Self {
             color_formats,
             flags,
-            group_size: PreferredGroupSize::EntireImage,
+            fragment_size: PreferredFragmentSize::EntireImage,
             encode,
         }
     }
@@ -104,7 +104,7 @@ impl Encoder {
         Self {
             color_formats: ColorFormatSet::from_single(color),
             flags: Flags::exact_for(color.precision),
-            group_size: PreferredGroupSize::EntireImage,
+            fragment_size: PreferredFragmentSize::EntireImage,
             encode: copy_directly,
         }
     }
@@ -113,8 +113,8 @@ impl Encoder {
         self.flags = self.flags.union(flags);
         self
     }
-    pub const fn with_group_size(mut self, group_size: PreferredGroupSize) -> Self {
-        self.group_size = group_size;
+    pub const fn with_fragment_size(mut self, fragment_size: PreferredFragmentSize) -> Self {
+        self.fragment_size = fragment_size;
         self
     }
 
@@ -207,7 +207,7 @@ impl EncoderSet {
             split_height: self.split_height,
             local_dithering: self.local_dithering(),
             size_multiple: self.size_multiple,
-            group_size: self.encoders[0].group_size,
+            fragment_size: self.encoders[0].fragment_size,
         }
     }
 

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -353,7 +353,10 @@ pub(crate) enum PreferredGroupSize {
 impl PreferredGroupSize {
     pub const fn group(fast: u64, high: u64, unreasonable: u64) -> Self {
         const fn log2(x: u64) -> u8 {
-            64 - x.leading_zeros() as u8
+            debug_assert!(x != 0);
+            debug_assert!(x.is_power_of_two());
+
+            64 - x.leading_zeros() as u8 - 1
         }
 
         Self::Group {


### PR DESCRIPTION
This PR lowers the group sizes required for images to be split when encoding with BCn.

Other changes:
- Fixed a bug in `PreferredFragmentSize::new` where log2 wasn't calculated correctly.
- Changed terminology of "group size" to "fragment size" when talking about split views. This caused a lot of code changes, but makes the code easier to understand.

## Background

Parallelization comes with overhead, so I decided to only parallelize images that are large enough to make it worth it. This is done via `SplitView`. `SplitView` splits an image into multiple independent fragments that together make up the whole image. Currently, BCn formats define a minimum size for these fragments by requiring that they contain a certain number of pixels. E.g. BC1 with High quality requires >=256 pixels per fragment. This is called the preferred fragment size.

This system ensures that small images aren't needlessly parallelized. The minimum size for parallelization can be controlled using the preferred fragment size.

## Benchmark

I added a new benchmark to measure the time it takes to encode a single surface of a given size with a given format and quality, with and without parallelization. I compared (1) single-threaded performance, (2) parallelization with old fragment sizes, and (3) parallelization with new fragment sizes.

(Times are with PR #72 already applied.)

| Format    | Quality | Image size | One thread |   Old par |   New par | Speed up |
| --------- | ------- | ---------- | ---------: | --------: | --------: | -------: |
| BC1_UNORM | Fast    | 64x64      |    0.23 ms |   0.23 ms |   0.22 ms |          |
|           |         | 128x128    |    0.94 ms |   0.92 ms |   0.38 ms |     2.4x |
|           |         | 256x256    |    3.75 ms |   3.65 ms |   0.74 ms |     4.9x |
|           |         | 512x512    |   14.99 ms |   7.60 ms |   2.24 ms |     3.4x |
|           |         | 1024x1024  |   60.03 ms |  11.78 ms |   8.43 ms |     1.4x |
|           | Normal  | 64x64      |    1.19 ms |   1.17 ms |   0.48 ms |     2.4x |
|           |         | 128x128    |    4.73 ms |   4.61 ms |   0.99 ms |     4.7x |
|           |         | 256x256    |   19.01 ms |   9.66 ms |   2.96 ms |     3.3x |
|           |         | 512x512    |   75.72 ms |  15.44 ms |  10.96 ms |     1.4x |
|           |         | 1024x1024  |  304.36 ms |  46.38 ms |  42.94 ms |          |
|           | High    | 64x64      |    3.33 ms |   3.28 ms |   0.70 ms |     4.7x |
|           |         | 128x128    |   13.38 ms |   6.80 ms |   2.11 ms |     3.2x |
|           |         | 256x256    |   52.89 ms |  10.94 ms |   8.14 ms |     1.3x |
|           |         | 512x512    |  213.35 ms |  32.68 ms |  30.75 ms |          |
|           |         | 1024x1024  |  853.56 ms | 122.18 ms | 123.64 ms |          |
|           |         |            |            |           |           |          |
| BC4_UNORM | Fast    | 64x64      |    0.16 ms |   0.15 ms |   0.15 ms |          |
|           |         | 128x128    |    0.65 ms |   0.64 ms |   0.27 ms |     2.4x |
|           |         | 256x256    |    2.59 ms |   2.52 ms |   0.54 ms |     4.7x |
|           |         | 512x512    |   10.41 ms |  10.41 ms |   1.58 ms |     6.6x |
|           |         | 1024x1024  |   42.05 ms |  12.59 ms |   5.95 ms |     2.1x |
|           | Normal  | 64x64      |    0.34 ms |   0.34 ms |   0.22 ms |     1.5x |
|           |         | 128x128    |    1.42 ms |   1.41 ms |   0.32 ms |     4.4x |
|           |         | 256x256    |    5.58 ms |   5.60 ms |   0.90 ms |     6.2x |
|           |         | 512x512    |   22.77 ms |   7.56 ms |   3.28 ms |     2.3x |
|           |         | 1024x1024  |   91.85 ms |  16.97 ms |  12.87 ms |     1.3x |
|           | High    | 64x64      |    0.75 ms |   0.75 ms |   0.31 ms |     2.4x |
|           |         | 128x128    |    3.02 ms |   2.99 ms |   0.63 ms |     4.7x |
|           |         | 256x256    |   12.39 ms |   6.17 ms |   1.85 ms |     3.3x |
|           |         | 512x512    |   51.21 ms |   9.79 ms |   7.33 ms |     1.3x |
|           |         | 1024x1024  |  197.81 ms |  29.23 ms |  26.89 ms |          |

Note that:

1. There are no regressions (within the margin of error). Parallel encoding is now as fast as before, or faster.
2. There are no major changes to large images (>=1k). This is to be expected since they were already decently parallelized.
3. Medium-sized images (128-512) improved the most.
