### PR TITLE
Add support for cancelling encoding

### DIFF
--- a/src/encode/bc.rs
+++ b/src/encode/bc.rs
@@ -5,7 +5,7 @@ use crate::{
     encode::write_util::for_each_f32_rgba_rows,
     n4,
     util::{self, clamp_0_1},
-    EncodingError, Report,
+    EncodingError,
 };
 
 use super::{
@@ -26,7 +26,7 @@ fn block_universal<
         image,
         writer,
         options,
-        mut progress,
+        progress,
         ..
     } = args;
     let width = image.width() as usize;
@@ -46,11 +46,13 @@ fn block_universal<
     };
     let block_count = util::div_ceil(width, BLOCK_WIDTH) * util::div_ceil(height, BLOCK_HEIGHT);
     let mut block_index: usize = 0;
-    let mut report_block = || {
-        if block_index % report_frequency == 0 {
-            progress.report(block_index as f32 / block_count as f32);
-        }
+    let mut report_block = || -> Result<(), EncodingError> {
+        progress.checked_report_if(
+            block_index % report_frequency == 0,
+            block_index as f32 / block_count as f32,
+        )?;
         block_index += 1;
+        Ok(())
     };
 
     for_each_f32_rgba_rows(image, BLOCK_HEIGHT, |rows| {
@@ -62,7 +64,7 @@ fn block_universal<
             let encoded = &mut encoded_buffer[block_index];
 
             encode_block(block, width, &options, encoded);
-            report_block();
+            report_block()?;
         }
 
         // handle last partial block
@@ -83,13 +85,13 @@ fn block_universal<
 
             let encoded = &mut encoded_buffer[block_index];
             encode_block(&block_data, BLOCK_WIDTH, &options, encoded);
-            report_block();
+            report_block()?;
         }
 
-        writer.write_all(cast::as_bytes(&encoded_buffer))
-    })?;
+        writer.write_all(cast::as_bytes(&encoded_buffer))?;
 
-    Ok(())
+        Ok(())
+    })
 }
 
 fn get_4x4_rgba(data: &[[f32; 4]], row_pitch: usize) -> [[f32; 4]; 16] {

--- a/src/encode/encoder.rs
+++ b/src/encode/encoder.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 
 use crate::{
     cast, encode::write_util::for_each_chunk, ColorFormat, ColorFormatSet, EncodingError,
-    ImageView, Precision, Progress, Report,
+    ImageView, Precision, Progress,
 };
 
 use super::{
@@ -14,14 +14,14 @@ use super::{
 pub(crate) struct Args<'a, 'b, 'c, 'd> {
     pub image: ImageView<'a>,
     pub writer: &'b mut dyn Write,
-    pub progress: Option<&'c mut Progress<'d>>,
+    pub progress: &'c mut Progress<'d>,
     pub options: EncodeOptions,
 }
 impl<'a, 'b, 'c, 'd> Args<'a, 'b, 'c, 'd> {
     fn from(
         image: ImageView<'a>,
         writer: &'b mut dyn Write,
-        progress: Option<&'c mut Progress<'d>>,
+        progress: &'c mut Progress<'d>,
         options: EncodeOptions,
     ) -> Result<Self, EncodingError> {
         Ok(Self {
@@ -245,7 +245,7 @@ impl EncoderSet {
         &self,
         writer: &mut dyn Write,
         image: ImageView,
-        progress: Option<&mut Progress>,
+        progress: &mut Progress,
         options: &EncodeOptions,
     ) -> Result<(), EncodingError> {
         let encoder = self.pick_encoder(image.color(), options);
@@ -258,12 +258,12 @@ fn copy_directly(args: Args) -> Result<(), EncodingError> {
     let Args {
         image,
         writer,
-        mut progress,
+        progress,
         ..
     } = args;
     let color = image.color();
 
-    progress.report(0.0);
+    progress.checked_report(0.0)?;
 
     // sometimes we can always just write everything directly without any processing
     if image.is_contiguous() && (cfg!(target_endian = "little") || color.precision == Precision::U8)

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -110,6 +110,24 @@ pub(crate) const fn get_encoders(format: Format) -> Option<EncoderSet> {
     })
 }
 
+/// Encodes a single surfaces in the given format and writes the encoded pixel
+/// data to the given writer.
+///
+/// If an error is returned (or the operation is cancelled), the writer may be
+/// in an inconsistent state. Some, all, or none of the pixel data may have been
+/// written.
+///
+/// If `progress` is cancelled before this function returns,
+/// [`EncodingError::Cancelled`] is returned (unless another error occurs first).
+/// Passing `None` as `progress` is equivalent to [`Progress::none()`].
+///
+/// ## Panics
+///
+/// Panics if:
+///
+/// 1. `writer` panics during writes.
+/// 2. The underlying reporter function of `progress` panics (if given).
+/// 3. An allocation fails.
 pub fn encode(
     writer: &mut dyn Write,
     image: ImageView,
@@ -117,13 +135,22 @@ pub fn encode(
     progress: Option<&mut Progress>,
     options: &EncodeOptions,
 ) -> Result<(), EncodingError> {
+    let mut no_reporting = Progress::none();
+    let progress = progress.unwrap_or(&mut no_reporting);
+
+    // ending quickly if cancelled is a good property to have
+    progress.check_cancelled()?;
+
     #[cfg(feature = "rayon")]
     if options.parallel {
         return encode_parallel(writer, image, format, progress, options);
     }
 
     let encoders = get_encoders(format).ok_or(EncodingError::UnsupportedFormat(format))?;
-    encoders.encode(writer, image, progress, options)
+    encoders.encode(writer, image, progress, options)?;
+
+    // error if the operation was cancelled
+    progress.check_cancelled()
 }
 
 #[cfg(feature = "rayon")]
@@ -131,12 +158,12 @@ fn encode_parallel(
     writer: &mut dyn Write,
     image: ImageView,
     format: Format,
-    mut progress: Option<&mut Progress>,
+    mut progress: &mut Progress,
     options: &EncodeOptions,
 ) -> Result<(), EncodingError> {
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-    use crate::{ParallelProgress, PixelInfo, Report, SplitView};
+    use crate::{ParallelProgress, PixelInfo, SplitView};
 
     let mut options = options.clone();
     // don't cause an infinite loop
@@ -146,7 +173,7 @@ fn encode_parallel(
 
     // optimization for single fragment
     if let Some(single) = split.single() {
-        return encode(writer, single, format, progress, &options);
+        return encode(writer, single, format, Some(progress), &options);
     }
 
     // Prepare the parallel progress reporter. The +1 ensures that 100% is
@@ -160,6 +187,7 @@ fn encode_parallel(
         .into_par_iter()
         .map(|fragment_index| -> Result<Vec<u8>, EncodingError> {
             let fragment = split.get(fragment_index).expect("invalid fragment index");
+            parallel_progress.check_cancelled()?;
 
             // allocate exactly the right amount of memory
             let bytes: usize = pixel_info
@@ -169,10 +197,12 @@ fn encode_parallel(
                 .expect("too many bytes");
             let mut buffer: Vec<u8> = Vec::with_capacity(bytes);
 
-            // encode the fragment without any progress reporting.
-            // progress will be reported per fragment
+            // Encode the fragment without any progress reporting or cancellation.
+            // Fragments are typically very small and encoded quickly, so
+            // reporting progress or checking for cancellation is not necessary.
             encode(&mut buffer, fragment, format, None, &options)?;
 
+            parallel_progress.check_cancelled()?;
             parallel_progress.submit(fragment.height() as u64);
 
             debug_assert_eq!(buffer.len(), bytes);
@@ -182,13 +212,12 @@ fn encode_parallel(
 
     let encoded_fragments = result?;
     for fragment in encoded_fragments {
+        progress.check_cancelled()?;
         writer.write_all(&fragment)?;
     }
 
-    // Report 100%
-    progress.report(1.0);
-
-    Ok(())
+    // report completion
+    progress.checked_report(1.0)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/encode/sub_sampled.rs
+++ b/src/encode/sub_sampled.rs
@@ -1,4 +1,4 @@
-use crate::{as_rgba_f32, cast, ch, n1, n8, util, yuv16, yuv8, EncodingError, Report};
+use crate::{as_rgba_f32, cast, ch, n1, n8, util, yuv16, yuv8, EncodingError};
 
 use super::encoder::{Args, Encoder, EncoderSet, Flags};
 
@@ -38,7 +38,7 @@ where
     let Args {
         image,
         writer,
-        mut progress,
+        progress,
         ..
     } = args;
     let color = image.color();
@@ -62,10 +62,11 @@ where
         debug_assert!(y_line.len() == width * bytes_per_pixel);
 
         for chunk in y_line.chunks(chunk_size) {
-            if chunk_index % 4096 == 0 {
-                // occasionally report progress
-                progress.report(chunk_index as f32 / chunk_count as f32);
-            }
+            // occasionally report progress
+            progress.checked_report_if(
+                chunk_index % 4096 == 0,
+                chunk_index as f32 / chunk_count as f32,
+            )?;
             chunk_index += 1;
 
             let pixels = chunk.len() / bytes_per_pixel;

--- a/src/error.rs
+++ b/src/error.rs
@@ -285,6 +285,10 @@ pub enum EncodingError {
     /// written all surfaces declared in the header.
     MissingSurfaces,
 
+    /// Returned when an operation given a [`CancellationToken`](crate::CancellationToken)
+    /// or [`Progress`](crate::Progress) was cancelled before or during the operation.
+    Cancelled,
+
     Layout(LayoutError),
     Io(std::io::Error),
 }
@@ -306,6 +310,8 @@ impl std::fmt::Display for EncodingError {
                 write!(f, "Too many surfaces are attempted to written")
             }
             EncodingError::MissingSurfaces => write!(f, "Not enough surfaces have been written"),
+
+            EncodingError::Cancelled => write!(f, "The operation was cancelled"),
 
             EncodingError::Layout(err) => write!(f, "Layout error: {err}"),
             EncodingError::Io(err) => write!(f, "IO error: {err}"),

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -1,4 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use dds::{header::*, *};
 use rand::{Rng, RngCore};
@@ -860,6 +866,109 @@ fn test_row_pitch() {
                 "Failed for {format:?}"
             );
             assert!(cont_encoded == non_cont_encoded, "Failed for {format:?}");
+        }
+    }
+}
+
+/// Tests that `encode` will never write anything if the given progress is already cancelled.
+#[test]
+fn test_immediate_cancel() {
+    let cancelled = CancellationToken::new();
+    cancelled.cancel();
+    let mut progress = Progress::none().with_cancellation(&cancelled);
+
+    let image: Image<u8> = Image::new_empty(Channels::Rgb, Size::new(2048, 2048));
+
+    let mut encoded = Vec::new();
+
+    let mut options = EncodeOptions::default();
+    for parallel in [false, true] {
+        options.parallel = parallel;
+
+        let result = encode(
+            &mut encoded,
+            image.view(),
+            Format::R8G8B8A8_UNORM,
+            Some(&mut progress),
+            &options,
+        );
+
+        assert!(matches!(result, Err(EncodingError::Cancelled)));
+        assert!(encoded.is_empty(), "Data was written even though cancelled");
+    }
+}
+
+/// Tests that `encode` will eventually cancel if the operation is cancelled
+/// while encoding.
+#[test]
+fn test_eventual_cancel() {
+    let image: Image<u8> = Image::new_empty(Channels::Rgb, Size::new(1024, 1024));
+
+    let mut options = EncodeOptions::default();
+    for parallel in [false, true] {
+        options.parallel = parallel;
+
+        for &format in util::ALL_FORMATS {
+            let cancelled = &CancellationToken::new();
+            let attempted_write = &Arc::new(AtomicBool::new(false));
+
+            let mut result = Ok(());
+
+            std::thread::scope(|s| {
+                // spawn a thread that will cancel the operation
+                s.spawn(|| {
+                    while !attempted_write.load(Ordering::SeqCst) && !cancelled.is_cancelled() {
+                        std::thread::yield_now();
+                    }
+                    cancelled.cancel();
+                });
+
+                // spawn a thread that will encode the image
+                s.spawn(|| {
+                    let mut progress = Progress::none().with_cancellation(cancelled);
+                    let mut writer = WriteUntilCancelled {
+                        token: cancelled.clone(),
+                        attempted_write: attempted_write.clone(),
+                    };
+                    result = encode(
+                        &mut writer,
+                        image.view(),
+                        format,
+                        Some(&mut progress),
+                        &options,
+                    );
+                    cancelled.cancel(); // ensure the other thread ends
+                });
+            });
+
+            assert!(
+                matches!(
+                    result,
+                    Err(EncodingError::Cancelled) | Err(EncodingError::UnsupportedFormat(_))
+                ),
+                "Expected cancellation but got {result:?} for {format:?}"
+            );
+        }
+    }
+
+    struct WriteUntilCancelled {
+        token: CancellationToken,
+        attempted_write: Arc<AtomicBool>,
+    }
+    impl std::io::Write for WriteUntilCancelled {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if !self.token.is_cancelled() {
+                self.attempted_write.store(true, Ordering::SeqCst);
+                while !self.token.is_cancelled() {
+                    std::thread::yield_now();
+                }
+            }
+
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
I added the ability to cancel encoding while it is running. This will enable use cases such as image editing programs allowing the user to stop encoding an image for preview purposes (e.g. Paint.net). This is mostly useful for formats such as BC1 that may take a few seconds or more to encode for large images.

This is implemented by extending the API of `Progress` to include an optional `CancellationToken`. Encoders regularly check the cancellation token (if any) and return an `EncodingError::Cancelled` if cancelled.

Internally, I took this opportunity to simplify the helper methods and traits around progress.

---

An alternative to `CancellationToken`s would be to make a wrapper around the writer and return an `IOError` when the encoding was cancelled. This more general approach to cancellation can be implemented by the user without this library explicitly having to support it. 

The problem is that it doesn't work well. For parallel encoding, the entire image is first encoded into a memory buffer before being written. So any writer-based cancellation is ineffective. Of course, parallel encoding is primarily used for computationally expensive formats. In other words, the formats that take a long time to encode (and are the motivation for cancelling) can't be canceled with the writer-based approach.