### PR TITLE
Use version range for glam dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ include = [
 [dependencies]
 astc-decode = "=0.3.1"
 bitflags = "2.4.0"
-glam = ">=0.25.0"
+glam = ">=0.25.0, <0.33"
 resize = { version = "0.8.4", default-features = false, features = ["std"] }
 zerocopy = "0.8.14"
 


### PR DESCRIPTION
Minor version bumps of crates that have not published a 1.0 can have breaking changes. Given that this crate cannot guarantee that future glam updates will not have changes that break compatibility it is safer to set a defined version range that is known to be compatible.